### PR TITLE
Global namespace cleanup

### DIFF
--- a/NuEVI/NuEVI.ino
+++ b/NuEVI/NuEVI.ino
@@ -5,6 +5,7 @@
 #include <EEPROM.h>
 #include <Filters.h>  // for the breath signal LP filtering, https://github.com/edgar-bonet/Filters
 
+#include "globals.h"
 #include "hardware.h"
 #include "midi.h"
 #include "menu.h"
@@ -115,14 +116,9 @@ int pbDepthList[13] = {8192,8192,4096,2731,2048,1638,1365,1170,1024,910,819,744,
 // the following variables are unsigned longs because the time, measured in
 // milliseconds, will quickly become a bigger number than can be stored in an int.
 
-unsigned long pixelUpdateTime = 0;
-unsigned long pixelUpdateInterval = 80;
-unsigned long cursorBlinkTime = 0;          // the last time the cursor was toggled
-unsigned long cursorBlinkInterval = 300;    // the cursor blink toggle interval time
-unsigned long patchViewTime = 0;
-unsigned long patchViewTimeUp = 2000;       // ms until patch view shuts off
-unsigned long menuTime = 0;
-unsigned long menuTimeUp = 60000;           // menu shuts off after one minute of button inactivity
+static unsigned long pixelUpdateTime = 0;
+static const unsigned long pixelUpdateInterval = 80;
+
 unsigned long lastDeglitchTime = 0;         // The last time the fingering was changed
 unsigned long ccSendTime = 0L;              // The last time we sent CC values
 unsigned long breath_on_time = 0L;          // Time when breath sensor value went over the ON threshold
@@ -140,7 +136,6 @@ byte doPatchUpdate=0;
 byte legacy = 0;
 byte legacyBrAct = 0;
 byte halfTime = 0;
-byte FPD = 0;
 boolean programonce = false;
 byte slowMidi = 0;
 

--- a/NuEVI/NuEVI.ino
+++ b/NuEVI/NuEVI.ino
@@ -849,9 +849,8 @@ void loop() {
     analogWrite(dacPin,breathCurve(map(constrain(pressureSensor,breathThrVal,breathMaxVal),breathThrVal,breathMaxVal,0,4095)));
   #endif
 
-  while (usbMIDI.read()) {
-    // read & ignore incoming messages
-  }
+  midiDiscardInput();
+
   //do menu stuff
   menu();
 }

--- a/NuEVI/globals.h
+++ b/NuEVI/globals.h
@@ -3,15 +3,15 @@
 
 #include "Wiring.h"
 
-extern unsigned short breathThrVal;//;
-extern unsigned short breathMaxVal;//;
-extern unsigned short portamThrVal;//;
-extern unsigned short portamMaxVal;//;
-extern unsigned short pitchbThrVal;//;
-extern unsigned short pitchbMaxVal;//;
-extern unsigned short extracThrVal;//;
-extern unsigned short extracMaxVal;//;
-extern unsigned short ctouchThrVal;//;
+extern unsigned short breathThrVal;
+extern unsigned short breathMaxVal;
+extern unsigned short portamThrVal;
+extern unsigned short portamMaxVal;
+extern unsigned short pitchbThrVal;
+extern unsigned short pitchbMaxVal;
+extern unsigned short extracThrVal;
+extern unsigned short extracMaxVal;
+extern unsigned short ctouchThrVal;
 extern unsigned short transpose;
 extern unsigned short MIDIchannel;
 extern unsigned short breathCC;  // OFF:MW:BR:VL:EX:MW+:BR+:VL+:EX+:CF
@@ -39,7 +39,6 @@ extern byte rotatorOn;
 extern byte currentRotation;
 extern int rotations[4];
 extern int parallel; // semitones
-extern byte gateOpen; // setting for gate always open, note on sent for every time fingering changes, no matter the breath status
 
 extern int breathLoLimit;
 extern int breathHiLimit;
@@ -61,30 +60,14 @@ extern int pitchbStep;
 extern int extracStep;
 extern int ctouchStep;
 
-
-extern unsigned long pixelUpdateTime;
-extern unsigned long pixelUpdateInterval;
 extern unsigned long cursorBlinkTime;          // the last time the cursor was toggled
-extern unsigned long cursorBlinkInterval;    // the cursor blink toggle interval time
-extern unsigned long patchViewTime;
-extern unsigned long patchViewTimeUp;       // ms until patch view shuts off
-extern unsigned long menuTime;
-extern unsigned long menuTimeUp;           // menu shuts off after one minute of button inactivity
-extern unsigned long lastDeglitchTime;         // The last time the fingering was changed
-extern unsigned long ccSendTime;              // The last time we sent CC values
-extern unsigned long breath_on_time;          // Time when breath sensor value went over the ON threshold
-extern int lastFingering;             // Keep the last fingering value for debouncing
-extern int mainState;                         // The state of the main state machine
-extern int initial_breath_value;          // The breath value at the time we observed the transition
-extern byte activeMIDIchannel;          // MIDI channel
+
 extern byte activePatch;
 extern byte doPatchUpdate;
 
 extern byte legacy;
 extern byte legacyBrAct;
-extern byte halfTime;
-extern byte FPD ;
-extern boolean programonce;
+
 extern byte slowMidi;
 
 extern int pressureSensor;  // pressure data from breath sensor, for midi breath cc and breath threshold checks

--- a/NuEVI/menu.cpp
+++ b/NuEVI/menu.cpp
@@ -37,16 +37,25 @@ static byte vibratoMenuCursor = 1;
 static byte cursorNow;
 static byte forcePix = 0;
 static byte forceRedraw = 0;
+static byte FPD = 0;
+
 
 static int pos1;
 static int pos2;
 
-static unsigned long lastDebounceTime = 0;         // the last time the output pin was toggled
 static const unsigned long debounceDelay = 30;           // the debounce time; increase if the output flickers
-static unsigned long buttonRepeatTime = 0;
-static unsigned long buttonPressedTime = 0;
 static const unsigned long buttonRepeatInterval = 50;
 static const unsigned long buttonRepeatDelay = 400;
+static const unsigned long cursorBlinkInterval = 300;    // the cursor blink toggle interval time
+static const unsigned long patchViewTimeUp = 2000;       // ms until patch view shuts off
+static const unsigned long menuTimeUp = 60000;           // menu shuts off after one minute of button inactivity
+
+static unsigned long lastDebounceTime = 0;         // the last time the output pin was toggled
+static unsigned long buttonRepeatTime = 0;
+static unsigned long buttonPressedTime = 0;
+static unsigned long menuTime = 0;
+static unsigned long patchViewTime = 0;
+unsigned long cursorBlinkTime = 0;          // the last time the cursor was toggled
 
 static int lastPbUp = 0;
 static int lastPbDn = 0;

--- a/NuEVI/midi.h
+++ b/NuEVI/midi.h
@@ -16,7 +16,7 @@ void midiSendNoteOff(byte note);
 void midiSendAfterTouch(byte value);
 void midiSendPitchBend(int value);
 
-
+void midiDiscardInput(void);
 void midiReset(); // reset controllers
 void midiPanic(); // turn all notes off
 

--- a/NuEVI/midi.ino
+++ b/NuEVI/midi.ino
@@ -50,6 +50,13 @@ void midiSendPitchBend(int value) {
     dinMIDIsendPitchBend(value, midiChannel - 1);
 }
 
+void midiDiscardInput()
+{
+  while (usbMIDI.read()) {
+    // read & ignore incoming messages
+  }
+}
+
 void midiReset() { // reset controllers
   midiSendControlChange(7, 100);
   midiSendControlChange(11, 127);


### PR DESCRIPTION
Moved variables only used in menu to menu code. Variables only used in NuEVI.ino removed from globals.h and made static.