### PR TITLE
Clever compiler tricks

### DIFF
--- a/NuEVI/NuEVI.ino
+++ b/NuEVI/NuEVI.ino
@@ -43,8 +43,8 @@ PROGRAMME FUNCTION:   EVI Wind Controller using the Freescale MP3V5004GP breath 
   #error "Wrong target platform. Please set to Teensy 3.1/3.2 (MK20DX256)."
 #endif
 
-#ifndef USB_MIDI
-  #error "USB_MIDI not enabled. Please set USB type to include MIDI."
+#if !defined(USB_MIDI) && !defined(USB_MIDI_SERIAL)
+  #error "USB MIDI not enabled. Please set USB type to 'MIDI' or 'Serial + MIDI'."
 #endif
 
 

--- a/NuEVI/NuEVI.ino
+++ b/NuEVI/NuEVI.ino
@@ -38,6 +38,14 @@ PROGRAMME FUNCTION:   EVI Wind Controller using the Freescale MP3V5004GP breath 
 // A note is sounding
 #define NOTE_ON 3
 
+//Make sure compiler is set to the appropriate platform
+#ifndef __MK20DX256__
+  #error "Wrong target platform. Please set to Teensy 3.1/3.2 (MK20DX256)."
+#endif
+
+#ifndef USB_MIDI
+  #error "USB_MIDI not enabled. Please set USB type to include MIDI."
+#endif
 
 
 //_______________________________________________________________________________________________ DECLARATIONS

--- a/NuEVI/hardware.h
+++ b/NuEVI/hardware.h
@@ -3,10 +3,6 @@
 
 #define REVB
 
-//Comment out the following line if you have Teensyduino 1.4.0 or earlier, to make pitch bend over USB-MIDI work.
-#define NEWTEENSYDUINO
-
-
 // Pin definitions
 
 // Teensy pins

--- a/NuEVI/midi.cpp
+++ b/NuEVI/midi.cpp
@@ -44,7 +44,7 @@ void midiSendAfterTouch(uint8_t value) {
 
 
 void midiSendPitchBend(uint16_t value) {
-    #if (TEENSYDUINO > 140)
+    #if (TEENSYDUINO >= 141)
     usbMIDI.sendPitchBend(value-8192, midiChannel); // newer teensyduino "pitchBend-8192" older just "pitchBend"... strange thing to change
     #else
     usbMIDI.sendPitchBend(value, midiChannel);

--- a/NuEVI/midi.cpp
+++ b/NuEVI/midi.cpp
@@ -44,7 +44,7 @@ void midiSendAfterTouch(uint8_t value) {
 
 
 void midiSendPitchBend(uint16_t value) {
-    #if defined(NEWTEENSYDUINO)
+    #if (TEENSYDUINO > 140)
     usbMIDI.sendPitchBend(value-8192, midiChannel); // newer teensyduino "pitchBend-8192" older just "pitchBend"... strange thing to change
     #else
     usbMIDI.sendPitchBend(value, midiChannel);

--- a/README.md
+++ b/README.md
@@ -28,10 +28,6 @@ and then add that in the Arduino IDE (under Sketch -> Include Library -> Add .ZI
 Open NuEVI.ino in the Arduino IDE. Under "Tools -> Board", select "Teensy 3.2 / 3.1". Then set
 "Tools -> USB Type" to "MIDI".
 
-If you have Teensyduino 1.4.0 or earlier, you also need to change an option in the code. In the
-Arduino Editor (where you have NuEVI.ino open), comment out the line with `#define NEWTEENSYDUINO`. If
-this does not match the Teensyduino version, pitch bend over USB-MIDI will not work properly.
-
 ### Building and uploading
 
 Connect the NuEVI via USB to your computer, open the Teensy application and make sure the "Auto"

--- a/simulation/Makefile
+++ b/simulation/Makefile
@@ -2,7 +2,7 @@ CC=clang
 CXX=clang++
 
 CFLAGS=-Wall -Wextra -Wpedantic -Wno-gnu -mmacosx-version-min=10.9 -F/Library/Frameworks
-CFLAGS += -DARDUINO=10808 -D__MK20DX256__
+CFLAGS += -DARDUINO=10808 -DTEENSYDUINO=146 -D__MK20DX256__ -DUSB_MIDI
 
 RELEASE ?= 0
 ifeq ($(RELEASE), 1)


### PR DESCRIPTION
Use build-environment-provided compiler constants to check for Teensyduino version, Teensy platform and USB type.