### PR TITLE
More correct display simulation

### DIFF
--- a/simulation/include/Adafruit_GFX.h
+++ b/simulation/include/Adafruit_GFX.h
@@ -16,6 +16,7 @@ public: // Exposed simulation variables...
   bool dimmed_;
   bool enabled_;
   bool inverted_;
+  bool dirty_;
 
  public:
 

--- a/simulation/src/Adafruit_SSD1306_sim.cpp
+++ b/simulation/src/Adafruit_SSD1306_sim.cpp
@@ -611,8 +611,7 @@ uint8_t *Adafruit_SSD1306::getBuffer(void) {
             of graphics commands, as best needed by one's own application.
 */
 void Adafruit_SSD1306::display(void) {
-
-  // TODO: Update SDL surface with content of `buffer`
+  dirty_ = true;
 
 }
 
@@ -723,6 +722,7 @@ void Adafruit_SSD1306::ssd1306_command(uint8_t cmd)
       break;
     case SSD1306_DISPLAYON:
       enabled_ = true;
+      dirty_ = true;
       break;
 
     default: break;

--- a/simulation/src/nuevisim.cpp
+++ b/simulation/src/nuevisim.cpp
@@ -47,8 +47,6 @@ void _reboot_Teensyduino_()
     setup();
 }
 
-extern void menu(void);
-extern void initDisplay(void);
 extern void breath();
 extern int noteValueCheck(int);
 extern unsigned int breathCurve(unsigned int);
@@ -188,7 +186,6 @@ static void touchWrite(uint8_t pin, uint16_t value)
 static void doGlobalsWindow()
 {
     if( ImGui::Begin("Globals" ) ) {
-
 
         if(ImGui::TreeNode("Sensor limits") )
         {
@@ -376,13 +373,15 @@ static uint8_t displayBuffer[128*128];
 
 static void GetDisplay()
 {
-    SDL_memset( displayBuffer, 0, (128*128));
-
-    if(display.enabled_) {
+    if(!display.enabled_) {
+        SDL_memset( displayBuffer, 0, (128*128));
+    } else if(display.dirty_) {
         uint8_t fg = 255;
         uint8_t bg = 0;
 
-        if( display.dimmed_) fg = 127;
+        display.dirty_ = false;
+
+        if( display.dimmed_ ) fg = 0b01001001;
         if( display.inverted_ ) { uint8_t tmp = fg; fg = bg; bg = tmp; }
 
         for(int y = 0 ; y < 64; ++y) {


### PR DESCRIPTION
enable/disable works more like the real thing, however not entirely correct. When enabling the display, it takes the current content of the screen buffer instead of the data that has been send to the display controller.