### PR TITLE
Menu option to set midibeam power level

### DIFF
--- a/NuEVI/NuEVI.ino
+++ b/NuEVI/NuEVI.ino
@@ -90,6 +90,8 @@ uint16_t gateOpenEnable = 0;
 
 uint16_t specialKeyEnable = 0;
 
+uint16_t wlPower = 0;
+
 int touch_Thr = 1300;
 
 byte ccList[11] = {0,1,2,7,11,1,2,7,11,74,20};  // OFF, Modulation, Breath, Volume, Expression (then same sent in hires), CC74 (cutoff/brightness), CC20 (UNO Cutoff)

--- a/NuEVI/globals.h
+++ b/NuEVI/globals.h
@@ -73,6 +73,8 @@ extern byte currentRotation;
 extern uint16_t rotations[4];
 extern uint16_t parallel; // semitones
 
+extern uint16_t wlPower;
+
 extern int touch_Thr;
 
 extern unsigned long cursorBlinkTime;          // the last time the cursor was toggled

--- a/NuEVI/menu.cpp
+++ b/NuEVI/menu.cpp
@@ -501,11 +501,22 @@ const MenuEntrySub specialKeyMenu = {
   , nullptr
 };
 
+
+const MenuEntrySub wlPowerMenu = {
+  MenuType::ESub, "WL POWER", "WL POWER", &wlPower, 0, 3, MenuEntryFlags::ENone,
+  [](SubMenuRef __unused, char* out, const char** __unused unit) {
+    numToString(-6*wlPower, out, true);
+  },
+  [](SubMenuRef __unused) { sendWLPower(wlPower); }
+  , nullptr
+};
+
 const MenuEntry* extrasMenuEntries[] = {
   (MenuEntry*)&legacyPBMenu,
   (MenuEntry*)&legacyBRMenu,
   (MenuEntry*)&gateOpenMenu,
   (MenuEntry*)&specialKeyMenu,
+  (MenuEntry*)&wlPowerMenu,
 };
 
 const MenuPage extrasMenuPage = {

--- a/NuEVI/midi.cpp
+++ b/NuEVI/midi.cpp
@@ -140,3 +140,27 @@ void dinMIDIsendAfterTouch(uint8_t value, uint8_t ch) {
 void dinMIDIsendProgramChange(uint8_t value, uint8_t ch) {
     midiSend2B((0xC0 | ch), value);
 }
+
+void dinMIDIsendSysex(const uint8_t data[], const uint8_t length) {
+  MIDI_SERIAL.write(0xF0); //Sysex command
+  for(int i=0; i<length; ++i) {
+    MIDI_SERIAL.write(data[i]);
+  }
+  MIDI_SERIAL.write(0xF7); //Sysex end
+}
+
+
+void sendWLPower(const uint8_t level) {
+  uint8_t buf[6] = {
+    0x00, 0x21, 0x11,  //Manufacturer id
+    0x02,             //TX02
+    0x02,             //Set power level
+    0x00              //Power level value (0-3)
+  };
+
+  if(level>3) return; //Don't send invalid values
+
+  buf[5] = level;
+  dinMIDIsendSysex(buf, 6);
+
+}

--- a/NuEVI/midi.h
+++ b/NuEVI/midi.h
@@ -28,5 +28,10 @@ void dinMIDIsendNoteOff(uint8_t note, uint8_t vel, uint8_t ch);
 void dinMIDIsendAfterTouch(uint8_t value, uint8_t ch);
 void dinMIDIsendProgramChange(uint8_t value, uint8_t ch);
 void dinMIDIsendPitchBend(uint16_t pb, uint8_t ch);
+void dinMIDIsendSysex(const uint8_t data[], const uint8_t length);
+
+
+
+void sendWLPower(const uint8_t level);
 
 #endif


### PR DESCRIPTION
Adds a submenu under extras to set wireless power ("WL POWER"). Options are called 0, -6, -12, -18 (for the power levels in dBm as stated in Midibeam manual).

The midibeam sends a sysex config dump on bootup. Default values:
`14:15:35.811	From Panda-Audio midiBeam	SysEx		Unknown Manufacturer 15 bytes	F0 00 21 11 02 01 08 10 08 02 00 00 0C 11 F7`

Sysex command sent when changing power level to -6dBm (0x01):
`14:31:00.430	From Panda-Audio midiBeam	SysEx		Unknown Manufacturer 8 bytes	F0 00 21 11 02 02 01 F7`

Resulting config dump after next bootup. The one byte differing is the radio power setting:
`14:32:01.249	From Panda-Audio midiBeam	SysEx		Unknown Manufacturer 15 bytes	F0 00 21 11 02 01 08 10 08 02 01 00 0C 11 F7`

There is a global value for wlPower, but it is literally only used to pass the value around in the menus. Nothing is currently stored in EEPROM, as there are no guarantees that the midibeam setting will still match what was last sent from the NuEVI. This should maybe be combined with a fair chunk of documentation before being sent to users, noone should really be messing with this value unless they know what they're doing.

Adding a radio channel setting in the same way would be relatively straightforward, but the point of having that is even more dubious as it is supposed to select channels dynamically.