### PR TITLE
Remove global var for wireless power, add wl channel menu

### DIFF
--- a/NuEVI/NuEVI.ino
+++ b/NuEVI/NuEVI.ino
@@ -90,8 +90,6 @@ uint16_t gateOpenEnable = 0;
 
 uint16_t specialKeyEnable = 0;
 
-uint16_t wlPower = 0;
-
 int touch_Thr = 1300;
 
 byte ccList[11] = {0,1,2,7,11,1,2,7,11,74,20};  // OFF, Modulation, Breath, Volume, Expression (then same sent in hires), CC74 (cutoff/brightness), CC20 (UNO Cutoff)

--- a/NuEVI/globals.h
+++ b/NuEVI/globals.h
@@ -73,8 +73,6 @@ extern byte currentRotation;
 extern uint16_t rotations[4];
 extern uint16_t parallel; // semitones
 
-extern uint16_t wlPower;
-
 extern int touch_Thr;
 
 extern unsigned long cursorBlinkTime;          // the last time the cursor was toggled

--- a/NuEVI/menu.cpp
+++ b/NuEVI/menu.cpp
@@ -501,15 +501,27 @@ const MenuEntrySub specialKeyMenu = {
   , nullptr
 };
 
+uint16_t wireless_power=0;
+uint16_t wireless_channel=4;
 
 const MenuEntrySub wlPowerMenu = {
-  MenuType::ESub, "WL POWER", "WL POWER", &wlPower, 0, 3, MenuEntryFlags::ENone,
+  MenuType::ESub, "WL POWER", "WL POWER", &wireless_power, 0, 3, MenuEntryFlags::ENone,
   [](SubMenuRef __unused, char* out, const char** __unused unit) {
-    numToString(-6*wlPower, out, true);
+    numToString(-6*wireless_power, out, true);
   },
-  [](SubMenuRef __unused) { sendWLPower(wlPower); }
+  [](SubMenuRef __unused) { sendWLPower(wireless_power); }
   , nullptr
 };
+
+const MenuEntrySub wlChannelMenu = {
+  MenuType::ESub, "WL CHAN", "WL CHAN", &wireless_channel, 4, 80, MenuEntryFlags::ENone,
+  [](SubMenuRef __unused, char* out, const char** __unused unit) {
+    numToString(wireless_channel, out, false);
+  },
+  [](SubMenuRef __unused) { sendWLChannel(wireless_channel); }
+  , nullptr
+};
+
 
 const MenuEntry* extrasMenuEntries[] = {
   (MenuEntry*)&legacyPBMenu,
@@ -517,6 +529,7 @@ const MenuEntry* extrasMenuEntries[] = {
   (MenuEntry*)&gateOpenMenu,
   (MenuEntry*)&specialKeyMenu,
   (MenuEntry*)&wlPowerMenu,
+  (MenuEntry*)&wlChannelMenu,
 };
 
 const MenuPage extrasMenuPage = {

--- a/NuEVI/midi.cpp
+++ b/NuEVI/midi.cpp
@@ -164,3 +164,19 @@ void sendWLPower(const uint8_t level) {
   dinMIDIsendSysex(buf, 6);
 
 }
+
+
+void sendWLChannel(const uint8_t channel) {
+  uint8_t buf[6] = {
+    0x00, 0x21, 0x11,  //Manufacturer id
+    0x02,             //TX02
+    0x05,             //Set channel
+    0x04              //Channel value (4-80)
+  };
+
+  if(channel<4 || channel>80) return; //Don't send invalid values
+
+  buf[5] = channel;
+  dinMIDIsendSysex(buf, 6);
+
+}

--- a/NuEVI/midi.h
+++ b/NuEVI/midi.h
@@ -30,8 +30,7 @@ void dinMIDIsendProgramChange(uint8_t value, uint8_t ch);
 void dinMIDIsendPitchBend(uint16_t pb, uint8_t ch);
 void dinMIDIsendSysex(const uint8_t data[], const uint8_t length);
 
-
-
 void sendWLPower(const uint8_t level);
+void sendWLChannel(const uint8_t channel);
 
 #endif


### PR DESCRIPTION
WL power does not need to be in a global as it is used nowhere else (and not stored in EEPROM).
Do a very similar thing with a WL channel submenu as well.