### PR TITLE
Configmode fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vscode/ipch
 *.o
 .DS_STORE
+*.code-workspace

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-.vscode/ipch
+.vscode
+.pio
 *.o
 .DS_STORE
 *.code-workspace

--- a/NuEVI/.gitignore
+++ b/NuEVI/.gitignore
@@ -1,5 +1,0 @@
-.pio
-.vscode/.browse.c_cpp.db*
-.vscode/c_cpp_properties.json
-.vscode/launch.json
-.vscode/ipch

--- a/NuEVI/NuEVI.ino
+++ b/NuEVI/NuEVI.ino
@@ -1347,7 +1347,7 @@ void loop() {
   }
   // Is it time to send more CC data?
   currentTime = millis();
-  if ((currentTime - ccBreathSendTime) > (breathInterval-1)){
+  if ((currentTime - ccBreathSendTime) >= breathInterval ) {
     breath();
     ccBreathSendTime = currentTime;
   }

--- a/NuEVI/settings.cpp
+++ b/NuEVI/settings.cpp
@@ -595,7 +595,7 @@ void handleSysex(uint8_t *data, unsigned int length) {
   } else if(!strncmp(messageCode, "c03", 3)) { //Version info request
     configShowMessage("Sending version.");
     sendSysexVersion();
-  } else if(!strncmp(messageCode, "c02", 3)) { //New config incoming
+  } else if(!strncmp(messageCode, "c01", 3) || !strncmp(messageCode, "c02", 3)) { //New config incoming. Accept both c01 and c02 so device will accept its own sysex dump.
     configShowMessage("Receiving config...");
 
     //Tell receiveSysexSettings about what's between sysex start and end markers

--- a/NuEVI/settings.cpp
+++ b/NuEVI/settings.cpp
@@ -663,6 +663,6 @@ void configModeLoop() {
       configShowMessage("Sending config...");
       sendSysexSettings();
       configShowMessage("Config sent.");
-      delay(3000);
+      delay(1500);
     }
 }

--- a/NuEVI/settings.cpp
+++ b/NuEVI/settings.cpp
@@ -500,6 +500,10 @@ bool receiveSysexSettings(const uint8_t* data, const uint16_t length) {
       if(val<ctouchLoLimit || val>ctouchHiLimit) continue;
     }
 
+    if(addr == LEVER_THR_ADDR || addr == LEVER_MAX_ADDR) {
+      if(val<leverLoLimit || val>leverHiLimit) continue;
+    }
+
     writeSetting(addr, val);
   }
 


### PR DESCRIPTION
*Makes device able to receive "it's own" sysex dumps (c01) as well as from NuControl (c02).
*Delay after manual sysex dump a bit shorter
*Include vibrato lever calibration values as "skippable"
*Unified .gitignore file