### PR TITLE
Pin Adafruit MPR121 library to 1.1.1, avoid bug in 1.2.x with Teensy3.x

### DIFF
--- a/NuEVI/platformio.ini
+++ b/NuEVI/platformio.ini
@@ -19,7 +19,7 @@ framework = arduino
 build_flags = -D USB_MIDI -D TEENSY_OPT_FASTER
 board_build.f_cpu = 96000000L
 lib_deps =
-  adafruit/Adafruit MPR121 @ ^1.1.1
+  adafruit/Adafruit MPR121 @ 1.1.1
   adafruit/Adafruit SSD1306 @ ^2.5.7
 
 [env:nuevi]


### PR DESCRIPTION
Something about MPR121 1.2.x, BusIO, and the Wire library for teensy 3.x doesn't work together, causing all inputs to read 0 (all buttons pressed).

https://github.com/adafruit/Adafruit_MPR121/issues/49