### PR TITLE
Config mode improvements

### DIFF
--- a/NuEVI/NuEVI.ino
+++ b/NuEVI/NuEVI.ino
@@ -624,7 +624,6 @@ FilterOnePole breathFilter;
 FilterOnePole piezoFilter;
 IntervalTimer cvTimer;
 
-bool configManagementMode = false;
 bool i2cScan = false;
 
 
@@ -702,7 +701,7 @@ void setup() {
   #endif
 
   bool factoryReset = !digitalRead(ePin) && !digitalRead(mPin) && digitalRead(dPin) && digitalRead(uPin);
-  configManagementMode = !digitalRead(uPin) && !digitalRead(dPin) && digitalRead(ePin) && digitalRead(mPin);
+  bool configManagementMode = !digitalRead(uPin) && !digitalRead(dPin) && digitalRead(ePin) && digitalRead(mPin);
   i2cScan = !factoryReset && !digitalRead(mPin);
 
   initDisplay(); //Start up display and show logo

--- a/NuEVI/NuEVI.ino
+++ b/NuEVI/NuEVI.ino
@@ -707,10 +707,10 @@ void setup() {
 
   initDisplay(); //Start up display and show logo
 
-  //If going into config management mode, stop here before we even touch the EEPROM.
+  //If going into config management mode, stop here and enter the loop before we even touch the EEPROM.
   if(configManagementMode) {
     configModeSetup();
-    return;
+    configModeLoop();
   }
 
   #if defined(I2CSCANNER)
@@ -887,12 +887,6 @@ void setup() {
 //_______________________________________________________________________________________________ MAIN LOOP
 
 void loop() {
-
-  //If in config mgmt loop, do that and nothing else
-  if(configManagementMode) {
-    configModeLoop();
-    return;
-  }
 
   breathFilter.input(analogRead(breathSensorPin));
   pressureSensor = constrain((int) breathFilter.output(), 0, 4095); // Get the filtered pressure sensor reading from analog pin A0, input from sensor MP3V5004GP

--- a/NuEVI/menu.cpp
+++ b/NuEVI/menu.cpp
@@ -2052,11 +2052,9 @@ const MenuPageCustom patchMenuPage =  { nullptr, EMenuPageCustom, patchPageUpdat
 const MenuPageCustom idleMenuPage =   { nullptr, EMenuPageCustom, idlePageUpdate };
 
 const MenuPageCustom aboutMenuPage =  { nullptr, EMenuPageCustom,
-  [](KeyState& __unused input, uint32_t __unused timeNow) -> bool {
-    static uint32_t timer = 0;
+  [](KeyState& input, uint32_t __unused timeNow) -> bool {
     if(stateFirstRun) {
       display.clearDisplay();
-      timer = timeNow + 3500;
       stateFirstRun = 0;
       display.setCursor(49,0);
       display.setTextColor(WHITE);
@@ -2131,14 +2129,26 @@ const MenuPageCustom aboutMenuPage =  { nullptr, EMenuPageCustom,
           display.print("v");
         }
       }
-
+      display.setCursor(16,50);
+      display.print("U+D for cfg mode");      
 
       return true;
     } else {
-      if(timeNow >= timer) {
+
+      // Menu or enter to exit
+      if (input.current & BTN_MENU) {
         menuState = MAIN_MENU;
         stateFirstRun = 1;
+        return true;
       }
+
+      // Up + down to enter config mode
+      if ((input.current & BTN_UP) && (input.current & BTN_DOWN)) {
+        midiPanic(); //For good measure, in case something is playing
+        configModeSetup();
+        configModeLoop();
+      }
+
       return false;
     }
   }

--- a/NuEVI/settings.cpp
+++ b/NuEVI/settings.cpp
@@ -658,6 +658,7 @@ bool resetSure(bool factoryReset){
 
 //"Main loop". Just sits and wait for midi messages and lets the sysex handler do all the work.
 void configModeLoop() {
+  while(1) {
     usbMIDI.read();
     if (!digitalRead(ePin)){
       configShowMessage("Sending config...");
@@ -665,4 +666,5 @@ void configModeLoop() {
       configShowMessage("Config sent.");
       delay(1500);
     }
+  }
 }

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ NuEVI is easiest to build using the Arduino IDE. You will also need to download 
 
 A few libraries need to be added that are not part of the default Arduino install. These can be
 added directly via the Library Manager in the Arduino IDE:
-* Adafruit MPR121
+* Adafruit MPR121 (version 1.1.1. 1.2.0 and later have compatibility issues with Teensy 3.2)
 * Adafruit GFX
 * Adafruit SSD1306 (version 1.2.9 or above)
-* NuEVI also includes on the [Filters](https://github.com/JonHub/Filters) library by Jonathan Driscoll, but that is no longer an external dependency.
+* NuEVI also includes the [Filters](https://github.com/JonHub/Filters) library by Jonathan Driscoll, but that is no longer an external dependency.
 
 
 ### Compile options


### PR DESCRIPTION
* Remove configMode check from main loop, have configModeLoop() be it's own forever loop
* Add feature to press U+D in about menu to enter config management mode
* Exit about menu by pressing "menu" (instead of a timer)
* Mention MPR121 library versions in readme