### PR TITLE
Refactor config management looping a bit, let the main loop() loop.

### DIFF
--- a/NuEVI/NuEVI.ino
+++ b/NuEVI/NuEVI.ino
@@ -625,6 +625,7 @@ FilterOnePole piezoFilter;
 IntervalTimer cvTimer;
 
 bool i2cScan = false;
+bool configManagementMode = false;
 
 
 //_______________________________________________________________________________________________ SETUP
@@ -701,7 +702,7 @@ void setup() {
   #endif
 
   bool factoryReset = !digitalRead(ePin) && !digitalRead(mPin) && digitalRead(dPin) && digitalRead(uPin);
-  bool configManagementMode = !digitalRead(uPin) && !digitalRead(dPin) && digitalRead(ePin) && digitalRead(mPin);
+  configManagementMode = !digitalRead(uPin) && !digitalRead(dPin) && digitalRead(ePin) && digitalRead(mPin);
   i2cScan = !factoryReset && !digitalRead(mPin);
 
   initDisplay(); //Start up display and show logo
@@ -709,7 +710,7 @@ void setup() {
   //If going into config management mode, stop here and enter the loop before we even touch the EEPROM.
   if(configManagementMode) {
     configModeSetup();
-    configModeLoop();
+    return;
   }
 
   #if defined(I2CSCANNER)
@@ -886,6 +887,12 @@ void setup() {
 //_______________________________________________________________________________________________ MAIN LOOP
 
 void loop() {
+
+  //If in config mgmt loop, do that and nothing else
+  if(configManagementMode) {
+    configModeLoop();
+    return;
+  }
 
   breathFilter.input(analogRead(breathSensorPin));
   pressureSensor = constrain((int) breathFilter.output(), 0, 4095); // Get the filtered pressure sensor reading from analog pin A0, input from sensor MP3V5004GP

--- a/NuEVI/globals.h
+++ b/NuEVI/globals.h
@@ -245,4 +245,6 @@ extern byte patchKey;
 
 extern unsigned int multiMap(unsigned short val, const unsigned short * _in, const unsigned short * _out, uint8_t size);
 
+extern bool configManagementMode;
+
 #endif

--- a/NuEVI/menu.cpp
+++ b/NuEVI/menu.cpp
@@ -2083,9 +2083,10 @@ const MenuPageCustom aboutMenuPage =  { nullptr, EMenuPageCustom,
 
       // Up + down to enter config mode
       if ((input.current & BTN_UP) && (input.current & BTN_DOWN)) {
+        menuState = DISPLAYOFF_IDL;
         midiPanic(); //For good measure, in case something is playing
+        configManagementMode = true;
         configModeSetup();
-        configModeLoop();
       }
 
       return false;

--- a/NuEVI/settings.cpp
+++ b/NuEVI/settings.cpp
@@ -658,13 +658,11 @@ bool resetSure(bool factoryReset){
 
 //"Main loop". Just sits and wait for midi messages and lets the sysex handler do all the work.
 void configModeLoop() {
-  while(1) {
-    usbMIDI.read();
-    if (!digitalRead(ePin)){
-      configShowMessage("Sending config...");
-      sendSysexSettings();
-      configShowMessage("Config sent.");
-      delay(1500);
-    }
+  usbMIDI.read();
+  if (!digitalRead(ePin)){
+    configShowMessage("Sending config...");
+    sendSysexSettings();
+    configShowMessage("Config sent.");
+    delay(1500);
   }
 }


### PR DESCRIPTION
Avoid looping forever anywhere but main loop, maintain simulator compatibility. Looks more like it did pre #52 .