### PR TITLE
Refactor defines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .DS_STORE
 *.code-workspace
 simulation/nuevisim
+.claude

--- a/NuEVI/NuEVI.ino
+++ b/NuEVI/NuEVI.ino
@@ -166,6 +166,7 @@ int calOffsetRH[12] = {-88,-68,-31,13,4,120,121,-68,-85,-34,23,87};
 int calOffsetLH[12] = {90,-13,-33,-93,-82,115,118,2,4,-40,-75,-94};
 #endif
 #endif
+
 #if defined(NUEVI_R2)
 int calOffsetRollers[12] = {0,0,0,0,0,0,-120,-120,-120,-120,-120,-120};
 int calOffsetRH[12] =      {0,0,0,0,0,0,0,0,0,0,0,0};
@@ -225,7 +226,7 @@ int piezoSens = 20;
 int piezoSquelch = 5;
 int piezoVib = 0;
 
- int allPiezo = 1;
+int allPiezo = 1;
 
 float filterVal = 0.15;
 float smoothedVal;
@@ -235,11 +236,7 @@ byte velocitySend;   // remapped midi velocity from breath sensor (or set to sta
 int breathCalZero;
 
 int leverPortZero;
-#if defined(NURAD)
 int leverPortThr = 70;
-#else
-int leverPortThr = 70;
-#endif
 int leverPortRead;
 int stripRead;
 int center;
@@ -568,7 +565,9 @@ byte K4;   // Left Hand index finger (pitch change -5)
 byte K5;   // Trill key 1 (pitch change +2)
 byte K6;   // Trill key 2 (pitch change +1)
 byte K7;   // Trill key 3 (pitch change +4)
-#else
+#endif
+
+#if defined(NUEVI)
 // Key variables, TRUE (1) for pressed, FALSE (0) for not pressed
 byte K1;   // Valve 1 (pitch change -2)
 byte K2;   // Valve 2 (pitch change -1)
@@ -578,6 +577,7 @@ byte K5;   // Trill key 1 (pitch change +2)
 byte K6;   // Trill key 2 (pitch change +1)
 byte K7;   // Trill key 3 (pitch change +4)
 #endif
+
 byte R1;
 byte R2;
 byte R3;
@@ -613,13 +613,16 @@ Adafruit_MPR121 touchSensorRollers = Adafruit_MPR121();
 Adafruit_MPR121 touchSensorRH = Adafruit_MPR121();
 Adafruit_MPR121 touchSensorLH = Adafruit_MPR121();
 #endif
+
 #if defined(NUEVI_R2)
 Adafruit_MPR121 touchSensorRollers = Adafruit_MPR121(); // roller and touch sensors on R2
 Adafruit_MPR121 touchSensorRH = Adafruit_MPR121(); // key board sensors on R2
 #endif
+
 #if defined(NUEVI_R1)
 Adafruit_MPR121 touchSensor = Adafruit_MPR121(); // This is the 12-input touch sensor
 #endif
+
 FilterOnePole breathFilter;
 FilterOnePole piezoFilter;
 IntervalTimer cvTimer;
@@ -639,6 +642,7 @@ void cvUpdate(){
     analogWrite(dacPin,map(constrain(cvPressure,breathThrVal,4095),breathThrVal,4095,0,4095));
   }
   #endif
+  
   #if defined(NUEVI_R1)
   int cvPressure = analogRead(breathSensorPin);
   if(dacMode == DAC_MODE_PITCH){
@@ -655,11 +659,13 @@ void setup() {
 
   analogReadResolution(12);   // set resolution of ADCs to 12 bit
   analogWriteResolution(12);
-  #if !defined(PLATFORM_R2)
+  
+  #if defined(PLATFORM_R1)
   analogWriteFrequency(pwmDacPin,11718.75);
   #else
   analogWriteFrequency(dacPin,36621.09);
   #endif
+
   Wire.setClock(1000000);
 
   pinMode(dPin, INPUT_PULLUP);
@@ -671,7 +677,7 @@ void setup() {
   pinMode(pLedPin, OUTPUT);        // portam indicator LED
   pinMode(statusLedPin,OUTPUT);    // Teensy onboard LED
   pinMode(dacPin, OUTPUT);         //DAC output for analog signal
-  #if !defined(PLATFORM_R2)
+  #if defined(PLATFORM_R1)
   pinMode(pwmDacPin, OUTPUT);      //PWMed DAC output for analog signal
   #endif
   #if defined(NURAD)
@@ -690,14 +696,16 @@ void setup() {
 
   widiJumper = !digitalRead(widiJumperPin); //WIDI
 
-  #if defined(PLATFORM_R2)
-  Serial7.setRX (28); //WIDI
-  Serial7.setTX (29); //WIDI
-  #else
+  #if defined(PLATFORM_R1)
   Serial2.setRX (26); //WIDI
   Serial2.setTX (31); //WIDI
   #endif
 
+  #if defined(PLATFORM_R2)
+  Serial7.setRX (28); //WIDI
+  Serial7.setTX (29); //WIDI
+  #endif
+  
   bool factoryReset = !digitalRead(ePin) && !digitalRead(mPin) && digitalRead(dPin) && digitalRead(uPin);
   configManagementMode = !digitalRead(uPin) && !digitalRead(dPin) && digitalRead(ePin) && digitalRead(mPin);
   i2cScan = !factoryReset && !digitalRead(mPin);
@@ -760,6 +768,7 @@ void setup() {
   digitalWrite(statusLedPin,LOW);
 
   #endif
+
   #if defined(NUEVI_R2)
    if (!touchSensorRollers.begin(0x5A)) {
     while (1){  // Touch sensor initialization failed - stop doing stuff
@@ -772,13 +781,13 @@ void setup() {
     }
   }
   #endif
+
   #if defined(NUEVI_R1)
   if (!touchSensor.begin(0x5A)) {
     while (1){  // Touch sensor initialization failed - stop doing stuff
       if (!digitalRead(dPin) && !digitalRead(ePin) && !digitalRead(uPin) && !digitalRead(mPin)) _reboot_Teensyduino_(); // reboot to program mode if all buttons pressed
     }
   }
-
   #endif
 
 
@@ -799,7 +808,7 @@ void setup() {
   #endif
 
   //auto-calibrate the vibrato threshold while showing splash screen
-  #if defined(NURAD_R2)
+#if defined(NURAD_R2)
   vibZero = vibZeroBite = breathCalZero = 0;
   const int sampleCount = 4;
   for(int i = 1 ; i <= sampleCount; ++i) {
@@ -810,6 +819,7 @@ void setup() {
     delay(fastBoot?75:220); //Shorter delay for fastboot
   }
 #endif
+
 #if defined(NUEVI_R2)
   vibZero = vibZeroBite = breathCalZero = 0;
   const int sampleCount = 4;
@@ -821,6 +831,7 @@ void setup() {
     delay(fastBoot?75:220); //Shorter delay for fastboot
   }
 #endif
+
 #if defined(PLATFORM_R1)
   vibZero = vibZeroBite = breathCalZero = 0;
   const int sampleCount = 4;
@@ -832,6 +843,7 @@ void setup() {
     delay(fastBoot?75:220); //Shorter delay for fastboot
   }
 #endif
+
   vibZero /= sampleCount;
   breathCalZero /= sampleCount;
   vibZeroBite /= sampleCount;
@@ -840,7 +852,7 @@ void setup() {
   vibThrLo = vibZero + vibSquelch;
   vibThrBite = vibZeroBite - vibSquelchBite;
   vibThrBiteLo = vibZeroBite + vibSquelchBite;
- #if !defined(PLATFORM_R2)
+ #if defined(PLATFORM_R1)
   patchKeyThrEVI = touchRead(patchPinEVI) + hackyTouchOffset;
   lockGlideKeyThr = touchRead(lockGlidePin) + hackyTouchOffset;
 #endif
@@ -880,7 +892,7 @@ void setup() {
   //Serial.begin(9600); // debug
 
   statusLedOn();    // Switch on the onboard LED to indicate power on/ready
-  #if !defined(PLATFORM_R2)
+  #if defined(PLATFORM_R1)
   cvTimer.begin(cvUpdate,500); // Update breath CV output every 500 microseconds
   #endif
 }
@@ -923,14 +935,17 @@ void loop() {
       bool patchKeyEVI = 0;
       bool lockGlideKey = 0;
       #endif
+
       #if defined(NUEVI_R2)
       bool patchKeyEVI = patchKey;
       bool lockGlideKey = 0;
       #endif
+      
       #if defined(PLATFORM_R1)
       bool patchKeyEVI = touchRead(patchPinEVI) > patchKeyThrEVI;
       bool lockGlideKey = touchRead(lockGlidePin) > lockGlideKeyThr;
       #endif
+      
       bool bothPB = (pbUp > ((pitchbMaxVal + pitchbThrVal) / 2)) && (pbDn > ((pitchbMaxVal + pitchbThrVal) / 2));
       bool justPbDn = !(pbUp > ((pitchbMaxVal + pitchbThrVal) / 2)) && (pbDn > ((pitchbMaxVal + pitchbThrVal) / 2));
       bool justPbUp = (pbUp > ((pitchbMaxVal + pitchbThrVal) / 2)) && !(pbDn > ((pitchbMaxVal + pitchbThrVal) / 2));
@@ -1077,10 +1092,11 @@ void loop() {
     }
 
     if (analogRead(breathSensorPin) > (breathCalZero - 850)) programonce = false;
-    #if defined(NURAD) || defined(NUEVI_R2)
-    #else
+    
+    #if defined(NUEVI_R1)
     specialKey = (touchRead(specialKeyPin) > touch_Thr); //S2 on pcb
     #endif
+
     if (polySelect != EHarmonizerOff) {
       if (lastSpecialKey != specialKey) {
         if (specialKey) {
@@ -1643,8 +1659,7 @@ void pitch_bend() {
     if (biteJumper){ //PBITE (if pulled low with jumper, or NuRAD compile, use pressure sensor instead of capacitive bite sensor)
       vibReadBite = analogRead(bitePressurePin); // alternative kind bite sensor (air pressure tube and sensor)  PBITE
     } else {
-#if defined(PLATFORM_R2)
-#else
+#if defined(PLATFORM_R1)
       vibReadBite = touchRead(bitePin);     // get sensor data, do some smoothing - SENSOR PIN 17 - PCB PINS LABELED "BITE" (GND left, sensor pin right)
 #endif
     }
@@ -1808,7 +1823,9 @@ void doorKnobCheck() {
         delay(600);
       }
     }
-    #else
+    #endif
+
+    #if defined(NUEVI)
     if (K4 && R1 && R2 && R3) { // doorknob grip on canister
       if (!gateOpen && (pbUp > ((pitchbMaxVal + pitchbThrVal) / 2))) {
         gateOpen = 1;
@@ -2003,8 +2020,7 @@ void portamento_() {
     if (biteJumper) { //PBITE (if pulled low with jumper or if on a NuRAD, use pressure sensor instead of capacitive bite sensor)
       biteSensor=analogRead(bitePressurePin); // alternative kind bite sensor (air pressure tube and sensor)  PBITE
     } else {
-#if defined(PLATFORM_R2)
-#else
+#if defined(PLATFORM_R1)
       biteSensor = touchRead(bitePin);     // get sensor data, do some smoothing - SENSOR PIN 17 - PCB PINS LABELED "BITE" (GND left, sensor pin right)
 #endif
    }
@@ -2019,6 +2035,7 @@ void portamento_() {
 #else
     leverPortRead = touchRead(vibratoPin);
 #endif
+
 #if defined(SEAMUS) || defined(PLATFORM_R2)
     if (portamento && ((leverPortRead) >= leverThrVal)) { // if we are enabled and over the threshold, send portamento
       portSumCC += map(constrain((leverPortRead), leverThrVal, leverMaxVal), leverThrVal, leverMaxVal, 0, 127);
@@ -2102,8 +2119,7 @@ void biteCC_() {
     if (biteJumper) { //PBITE (if pulled low with jumper or if on a NuRAD, use pressure sensor instead of capacitive bite sensor)
       biteSensor=analogRead(bitePressurePin); // alternative kind bite sensor (air pressure tube and sensor)  PBITE
     } else {
- #if defined(PLATFORM_R2)
- #else
+ #if defined(PLATFORM_R1)
       biteSensor = touchRead(bitePin);     // get sensor data, do some smoothing - SENSOR PIN 17 - PCB PINS LABELED "BITE" (GND left, sensor pin right)
  #endif
     }
@@ -2126,6 +2142,7 @@ void leverCC_() {
 #else
     leverPortRead = touchRead(vibratoPin);
 #endif
+
 #if defined(SEAMUS) || defined(PLATFORM_R2)
     if (((leverPortRead) >= leverThrVal)) { // we are over the threshold, calculate CC value
       leverCClevel = map(constrain((leverPortRead), leverThrVal, leverMaxVal), leverThrVal, leverMaxVal, 0, 127);
@@ -2135,6 +2152,7 @@ void leverCC_() {
       leverCClevel = map(constrain((3000-leverPortRead), leverThrVal, leverMaxVal), leverThrVal, leverMaxVal, 0, 127);
     }
 #endif
+
     if (leverCClevel != oldlevercc) {
       midiSendControlChange(leverCC, leverCClevel);
       oldlevercc = leverCClevel;
@@ -2215,8 +2233,9 @@ void autoCal() {
   ctouchThrVal = constrain(calRead-20, ctouchLoLimit, ctouchHiLimit);
   touch_Thr = map(ctouchThrVal,ctouchHiLimit,ctouchLoLimit,ttouchLoLimit,ttouchHiLimit);
   writeSetting(CTOUCH_THR_ADDR, ctouchThrVal);
-#else // NuEVI sensor calibration
-#if defined(NUEVI_R2)
+#endif
+
+#if defined(NUEVI_R2) // NuEVI R2sensor calibration
  // Bite Pressure sensor
   calRead = analogRead(bitePressurePin);
   portamThrVal = constrain(calRead+800, portamLoLimit, portamHiLimit);
@@ -2237,7 +2256,9 @@ void autoCal() {
   ctouchThrVal = constrain(calRead-20, ctouchLoLimit, ctouchHiLimit);
   touch_Thr = map(ctouchThrVal,ctouchHiLimit,ctouchLoLimit,ttouchLoLimit,ttouchHiLimit);
   writeSetting(CTOUCH_THR_ADDR, ctouchThrVal);
-#else 
+#endif
+
+#if defined(NUEVI_R1) // NuEVI R1 sensor calibration
   // Bite sensor
   if (digitalRead(biteJumperPin)){ //PBITE (if pulled low with jumper, pressure sensor is used instead of capacitive bite sensing)
     // Capacitive sensor
@@ -2268,7 +2289,7 @@ void autoCal() {
   touch_Thr = map(ctouchThrVal,ctouchHiLimit,ctouchLoLimit,ttouchLoLimit,ttouchHiLimit);
   writeSetting(CTOUCH_THR_ADDR, ctouchThrVal);
 #endif
-#endif
+
 }
 
 

--- a/NuEVI/NuEVI.ino
+++ b/NuEVI/NuEVI.ino
@@ -166,7 +166,7 @@ int calOffsetRH[12] = {-88,-68,-31,13,4,120,121,-68,-85,-34,23,87};
 int calOffsetLH[12] = {90,-13,-33,-93,-82,115,118,2,4,-40,-75,-94};
 #endif
 #endif
-#if defined(EVIR2)
+#if defined(NUEVI_R2)
 int calOffsetRollers[12] = {0,0,0,0,0,0,-120,-120,-120,-120,-120,-120};
 int calOffsetRH[12] =      {0,0,0,0,0,0,0,0,0,0,0,0};
 #endif
@@ -613,7 +613,7 @@ Adafruit_MPR121 touchSensorRollers = Adafruit_MPR121();
 Adafruit_MPR121 touchSensorRH = Adafruit_MPR121();
 Adafruit_MPR121 touchSensorLH = Adafruit_MPR121();
 #else
-#if defined(EVIR2)
+#if defined(NUEVI_R2)
 Adafruit_MPR121 touchSensorRollers = Adafruit_MPR121(); // roller and touch sensors on R2
 Adafruit_MPR121 touchSensorRH = Adafruit_MPR121(); // key board sensors on R2
 #else
@@ -633,7 +633,7 @@ bool configManagementMode = false;
 //Update CV output pin, run from timer.
 void cvUpdate(){
   #if defined(NURAD)
-  #if !defined(LITE)
+  #if defined(NURAD_R1)
   int cvPressure = analogRead(breathSensorPin);
   analogWrite(pwmDacPin,map(constrain(cvPressure,breathThrVal,breathMaxVal),breathThrVal,breathMaxVal,0,4095));
   if(dacMode == DAC_MODE_BREATH){
@@ -641,7 +641,7 @@ void cvUpdate(){
   }
   #endif
   #else //NuEVI
-  #if !defined(EVIR2)
+  #if defined(NUEVI_R1)
   int cvPressure = analogRead(breathSensorPin);
   if(dacMode == DAC_MODE_PITCH){
     analogWrite(pwmDacPin,cvPressure);
@@ -658,7 +658,7 @@ void setup() {
 
   analogReadResolution(12);   // set resolution of ADCs to 12 bit
   analogWriteResolution(12);
-  #if !defined(LITE) && !defined(EVIR2)
+  #if !defined(PLATFORM_R2)
   analogWriteFrequency(pwmDacPin,11718.75);
   #else
   analogWriteFrequency(dacPin,36621.09);
@@ -674,7 +674,7 @@ void setup() {
   pinMode(pLedPin, OUTPUT);        // portam indicator LED
   pinMode(statusLedPin,OUTPUT);    // Teensy onboard LED
   pinMode(dacPin, OUTPUT);         //DAC output for analog signal
-  #if !defined(LITE) && !defined(EVIR2)
+  #if !defined(PLATFORM_R2)
   pinMode(pwmDacPin, OUTPUT);      //PWMed DAC output for analog signal
   #endif
   #if defined(NURAD)
@@ -693,7 +693,7 @@ void setup() {
 
   widiJumper = !digitalRead(widiJumperPin); //WIDI
 
-  #if defined(LITE) || defined(EVIR2)
+  #if defined(PLATFORM_R2)
   Serial7.setRX (28); //WIDI
   Serial7.setTX (29); //WIDI
   #else
@@ -762,7 +762,7 @@ void setup() {
   delay(100);
   digitalWrite(statusLedPin,LOW);
 
-  #elif defined(EVIR2)
+  #elif defined(NUEVI_R2)
    if (!touchSensorRollers.begin(0x5A)) {
     while (1){  // Touch sensor initialization failed - stop doing stuff
       if (!digitalRead(dPin) && !digitalRead(ePin) && !digitalRead(uPin) && !digitalRead(mPin)) _reboot_Teensyduino_(); // reboot to program mode if all buttons pressed
@@ -785,12 +785,12 @@ void setup() {
 
   breathFilter.setFilter(LOWPASS, filterFreq, 0.0);   // create a one pole (RC) lowpass filter
 
-  #if defined(EVIR2)
+  #if defined(NUEVI_R2)
     center = analogRead(piezoPin); //calibrate center
     piezoFilter.setFilter(LOWPASS, piezoFilterFreq, 0.0);   // create a one pole (RC) lowpass filter
   #endif
 
-  #if defined(NURAD) || defined(EVIR2)
+  #if defined(NURAD) || defined(NUEVI_R2)
   biteJumper = true;
   #else
   biteJumper = !digitalRead(biteJumperPin);
@@ -800,7 +800,7 @@ void setup() {
   #endif
 
   //auto-calibrate the vibrato threshold while showing splash screen
-  #if defined(LITE)
+  #if defined(NURAD_R2)
   vibZero = vibZeroBite = breathCalZero = 0;
   const int sampleCount = 4;
   for(int i = 1 ; i <= sampleCount; ++i) {
@@ -810,7 +810,7 @@ void setup() {
     statusLed(i&1);
     delay(fastBoot?75:220); //Shorter delay for fastboot
   }
-#elif defined(EVIR2)
+#elif defined(NUEVI_R2)
   vibZero = vibZeroBite = breathCalZero = 0;
   const int sampleCount = 4;
   for(int i = 1 ; i <= sampleCount; ++i) {
@@ -839,7 +839,7 @@ void setup() {
   vibThrLo = vibZero + vibSquelch;
   vibThrBite = vibZeroBite - vibSquelchBite;
   vibThrBiteLo = vibZeroBite + vibSquelchBite;
- #if !defined(LITE) && !defined(EVIR2)
+ #if !defined(PLATFORM_R2)
   patchKeyThrEVI = touchRead(patchPinEVI) + hackyTouchOffset;
   lockGlideKeyThr = touchRead(lockGlidePin) + hackyTouchOffset;
 #endif
@@ -879,7 +879,7 @@ void setup() {
   //Serial.begin(9600); // debug
 
   statusLedOn();    // Switch on the onboard LED to indicate power on/ready
-  #if !defined(LITE) && !defined(EVIR2)
+  #if !defined(PLATFORM_R2)
   cvTimer.begin(cvUpdate,500); // Update breath CV output every 500 microseconds
   #endif
 }
@@ -918,10 +918,10 @@ void loop() {
       mainState = RISE_WAIT; // Go to next state
     }
     if (legacy || legacyBrAct) {
-      #if defined(LITE)
+      #if defined(NURAD_R2)
       bool patchKeyEVI = 0;
       bool lockGlideKey = 0;
-      #elif defined(EVIR2)
+      #elif defined(NUEVI_R2)
       bool patchKeyEVI = patchKey;
       bool lockGlideKey = 0;
       #else
@@ -1074,7 +1074,7 @@ void loop() {
     }
 
     if (analogRead(breathSensorPin) > (breathCalZero - 850)) programonce = false;
-    #if defined(NURAD) || defined(EVIR2)
+    #if defined(NURAD) || defined(NUEVI_R2)
     #else
     specialKey = (touchRead(specialKeyPin) > touch_Thr); //S2 on pcb
     #endif
@@ -1619,7 +1619,7 @@ void pitch_bend() {
   byte pbTouched = 0;
   int vibRead = 0;
   int vibReadBite = 0;
-#if defined(LITE) || defined(EVIR2)
+#if defined(PLATFORM_R2)
   pbUp = map(constrain(touchSensorRollers.filteredData(pbUpPin), ctouchLoLimit, ctouchHiLimit), ctouchLoLimit, ctouchHiLimit, pitchbHiLimit, pitchbLoLimit);
   pbDn = map(constrain(touchSensorRollers.filteredData(pbDnPin), ctouchLoLimit, ctouchHiLimit), ctouchLoLimit, ctouchHiLimit, pitchbHiLimit, pitchbLoLimit);
 #else
@@ -1640,7 +1640,7 @@ void pitch_bend() {
     if (biteJumper){ //PBITE (if pulled low with jumper, or NuRAD compile, use pressure sensor instead of capacitive bite sensor)
       vibReadBite = analogRead(bitePressurePin); // alternative kind bite sensor (air pressure tube and sensor)  PBITE
     } else {
-#if defined(LITE) || defined(EVIR2)
+#if defined(PLATFORM_R2)
 #else
       vibReadBite = touchRead(bitePin);     // get sensor data, do some smoothing - SENSOR PIN 17 - PCB PINS LABELED "BITE" (GND left, sensor pin right)
 #endif
@@ -1661,13 +1661,13 @@ void pitch_bend() {
       unmoved = 1;
     }
   }
-  #if defined(EVIR2)
+  #if defined(NUEVI_R2)
   if (1) { //piezo vibrato always on
   #else
   if (1 == leverControl) { //lever vibrato
   #endif
 
-#if defined(EVIR2)
+#if defined(NUEVI_R2)
     piezoFilter.input(analogRead(piezoPin));
     vibRead = piezoFilter.output();
     if (allPiezo){ //Using the piezo voltage and zeroing directly
@@ -1691,7 +1691,7 @@ void pitch_bend() {
       }
     }
 #else
-#if defined(LITE)
+#if defined(NURAD_R2)
     vibRead = map(constrain(touchSensorRollers.filteredData(vibratoPin), ctouchLoLimit, ctouchHiLimit), ctouchLoLimit, ctouchHiLimit, leverHiLimit, leverLoLimit);
 #else
     vibRead = touchRead(vibratoPin); // SENSOR PIN 15 - built in var cap
@@ -1844,7 +1844,7 @@ void extraController() {
   bool CC1sw = false;
   int extracCC;
   // Extra Controller is the lip touch sensor (proportional) in front of the mouthpiece
-  #if defined(LITE) || defined(EVIR2)
+  #if defined(PLATFORM_R2)
   exSensor = exSensor * 0.6 + 0.4 * map(constrain(touchSensorRollers.filteredData(extraPin), ctouchLoLimit, ctouchHiLimit), ctouchLoLimit, ctouchHiLimit, extracHiLimit, extracLoLimit);
   exSensor2 = exSensor2 * 0.6 + 0.4 * map(constrain(touchSensorRollers.filteredData(extraPin2), ctouchLoLimit, ctouchHiLimit), ctouchLoLimit, ctouchHiLimit, extracHiLimit, extracLoLimit);
   //if (extraSrc) exSensorUse = exSensor; else exSensorUse = exSensor2;
@@ -2000,7 +2000,7 @@ void portamento_() {
     if (biteJumper) { //PBITE (if pulled low with jumper or if on a NuRAD, use pressure sensor instead of capacitive bite sensor)
       biteSensor=analogRead(bitePressurePin); // alternative kind bite sensor (air pressure tube and sensor)  PBITE
     } else {
-#if defined(LITE) || defined(EVIR2)
+#if defined(PLATFORM_R2)
 #else
       biteSensor = touchRead(bitePin);     // get sensor data, do some smoothing - SENSOR PIN 17 - PCB PINS LABELED "BITE" (GND left, sensor pin right)
 #endif
@@ -2011,12 +2011,12 @@ void portamento_() {
   }
   if (2 == leverControl || 5 == leverControl || 6 == leverControl || 7 == leverControl) {
     // Portamento is controlled with thumb lever
-#if defined(LITE) || defined(EVIR2)
+#if defined(PLATFORM_R2)
     leverPortRead = map(constrain(touchSensorRollers.filteredData(vibratoPin), ctouchLoLimit, ctouchHiLimit), ctouchLoLimit, ctouchHiLimit, leverHiLimit, leverLoLimit);
 #else
     leverPortRead = touchRead(vibratoPin);
 #endif
-#if defined(SEAMUS) || defined(LITE) || defined(EVIR2)
+#if defined(SEAMUS) || defined(PLATFORM_R2)
     if (portamento && ((leverPortRead) >= leverThrVal)) { // if we are enabled and over the threshold, send portamento
       portSumCC += map(constrain((leverPortRead), leverThrVal, leverMaxVal), leverThrVal, leverMaxVal, 0, 127);
     }
@@ -2027,7 +2027,7 @@ void portamento_() {
 #endif
   }
 
-#if defined(LITE) || defined(EVIR2)
+#if defined(PLATFORM_R2)
   if (1 == stripControl) {
     // Portamento is controlled with glide strip/aux sensor
 
@@ -2099,7 +2099,7 @@ void biteCC_() {
     if (biteJumper) { //PBITE (if pulled low with jumper or if on a NuRAD, use pressure sensor instead of capacitive bite sensor)
       biteSensor=analogRead(bitePressurePin); // alternative kind bite sensor (air pressure tube and sensor)  PBITE
     } else {
- #if defined(LITE) || defined(EVIR2)
+ #if defined(PLATFORM_R2)
  #else
       biteSensor = touchRead(bitePin);     // get sensor data, do some smoothing - SENSOR PIN 17 - PCB PINS LABELED "BITE" (GND left, sensor pin right)
  #endif
@@ -2118,12 +2118,12 @@ void biteCC_() {
 void leverCC_() {
   int leverCClevel = 0;
   if (3 == leverControl){
-#if defined(LITE) || defined(EVIR2)
+#if defined(PLATFORM_R2)
     leverPortRead = map(constrain(touchSensorRollers.filteredData(vibratoPin), ctouchLoLimit, ctouchHiLimit), ctouchLoLimit, ctouchHiLimit, leverHiLimit, leverLoLimit);
 #else
     leverPortRead = touchRead(vibratoPin);
 #endif
-#if defined(SEAMUS) || defined(LITE) || defined(EVIR2)
+#if defined(SEAMUS) || defined(PLATFORM_R2)
     if (((leverPortRead) >= leverThrVal)) { // we are over the threshold, calculate CC value
       leverCClevel = map(constrain((leverPortRead), leverThrVal, leverMaxVal), leverThrVal, leverMaxVal, 0, 127);
     }
@@ -2144,7 +2144,7 @@ void autoCal() {
   int calReadNext;
 // NuRAD/NuEVI sensor calibration
   // Extra Controller
-#if defined(LITE) || defined(EVIR2)
+#if defined(PLATFORM_R2)
   calRead = map(constrain(touchSensorRollers.filteredData(extraPin), ctouchLoLimit, ctouchHiLimit), ctouchLoLimit, ctouchHiLimit, extracHiLimit, extracLoLimit);
   calReadNext = map(constrain(touchSensorRollers.filteredData(extraPin2), ctouchLoLimit, ctouchHiLimit), ctouchLoLimit, ctouchHiLimit, extracHiLimit, extracLoLimit);
   if (calReadNext > calRead) calRead = calReadNext; //use highest value
@@ -2162,7 +2162,7 @@ void autoCal() {
   writeSetting(BREATH_THR_ADDR, breathThrVal);
   writeSetting(BREATH_MAX_ADDR, breathMaxVal);
   // Pitch Bend
-#if defined(LITE) || defined(EVIR2)
+#if defined(PLATFORM_R2)
   calRead = map(constrain(touchSensorRollers.filteredData(pbUpPin), ctouchLoLimit, ctouchHiLimit), ctouchLoLimit, ctouchHiLimit, pitchbHiLimit, pitchbLoLimit);
   calReadNext = map(constrain(touchSensorRollers.filteredData(pbDnPin), ctouchLoLimit, ctouchHiLimit), ctouchLoLimit, ctouchHiLimit, pitchbHiLimit, pitchbLoLimit);
 #else
@@ -2175,12 +2175,12 @@ void autoCal() {
   writeSetting(PITCHB_THR_ADDR, pitchbThrVal);
   writeSetting(PITCHB_MAX_ADDR, pitchbMaxVal);
   // Lever
-#if defined(LITE) || defined(EVIR2)
+#if defined(PLATFORM_R2)
   calRead = map(constrain(touchSensorRollers.filteredData(vibratoPin), ctouchLoLimit, ctouchHiLimit), ctouchLoLimit, ctouchHiLimit, leverHiLimit, leverLoLimit);
 #else
   calRead = touchRead(vibratoPin);
 #endif
-#if defined(SEAMUS) || defined(LITE) || defined(EVIR2)
+#if defined(SEAMUS) || defined(PLATFORM_R2)
 #else
   calRead = 3000-calRead;
 #endif
@@ -2213,7 +2213,7 @@ void autoCal() {
   touch_Thr = map(ctouchThrVal,ctouchHiLimit,ctouchLoLimit,ttouchLoLimit,ttouchHiLimit);
   writeSetting(CTOUCH_THR_ADDR, ctouchThrVal);
 #else // NuEVI sensor calibration
-#if defined(EVIR2)
+#if defined(NUEVI_R2)
  // Bite Pressure sensor
   calRead = analogRead(bitePressurePin);
   portamThrVal = constrain(calRead+800, portamLoLimit, portamHiLimit);
@@ -2491,7 +2491,7 @@ void readSwitches() {
 #else //NuEVI
 
   // Read touch pads (MPR121), compare against threshold value
-  #if defined(EVIR2)
+  #if defined(NUEVI_R2)
       // RH keys
       int touchValueRH[12];
       for (byte i=0; i<12; i++){

--- a/NuEVI/NuEVI.ino
+++ b/NuEVI/NuEVI.ino
@@ -612,13 +612,13 @@ byte slurSostenuto = 0;
 Adafruit_MPR121 touchSensorRollers = Adafruit_MPR121();
 Adafruit_MPR121 touchSensorRH = Adafruit_MPR121();
 Adafruit_MPR121 touchSensorLH = Adafruit_MPR121();
-#else
+#endif
 #if defined(NUEVI_R2)
 Adafruit_MPR121 touchSensorRollers = Adafruit_MPR121(); // roller and touch sensors on R2
 Adafruit_MPR121 touchSensorRH = Adafruit_MPR121(); // key board sensors on R2
-#else
-Adafruit_MPR121 touchSensor = Adafruit_MPR121(); // This is the 12-input touch sensor
 #endif
+#if defined(NUEVI_R1)
+Adafruit_MPR121 touchSensor = Adafruit_MPR121(); // This is the 12-input touch sensor
 #endif
 FilterOnePole breathFilter;
 FilterOnePole piezoFilter;
@@ -632,7 +632,6 @@ bool configManagementMode = false;
 
 //Update CV output pin, run from timer.
 void cvUpdate(){
-  #if defined(NURAD)
   #if defined(NURAD_R1)
   int cvPressure = analogRead(breathSensorPin);
   analogWrite(pwmDacPin,map(constrain(cvPressure,breathThrVal,breathMaxVal),breathThrVal,breathMaxVal,0,4095));
@@ -640,7 +639,6 @@ void cvUpdate(){
     analogWrite(dacPin,map(constrain(cvPressure,breathThrVal,4095),breathThrVal,4095,0,4095));
   }
   #endif
-  #else //NuEVI
   #if defined(NUEVI_R1)
   int cvPressure = analogRead(breathSensorPin);
   if(dacMode == DAC_MODE_PITCH){
@@ -648,7 +646,6 @@ void cvUpdate(){
   } else { //DAC_MODE_BREATH
     analogWrite(dacPin,map(constrain(cvPressure,breathThrVal,4095),breathThrVal,4095,0,4095));
   }
-  #endif
   #endif
 }
 
@@ -762,7 +759,8 @@ void setup() {
   delay(100);
   digitalWrite(statusLedPin,LOW);
 
-  #elif defined(NUEVI_R2)
+  #endif
+  #if defined(NUEVI_R2)
    if (!touchSensorRollers.begin(0x5A)) {
     while (1){  // Touch sensor initialization failed - stop doing stuff
       if (!digitalRead(dPin) && !digitalRead(ePin) && !digitalRead(uPin) && !digitalRead(mPin)) _reboot_Teensyduino_(); // reboot to program mode if all buttons pressed
@@ -773,13 +771,14 @@ void setup() {
       if (!digitalRead(dPin) && !digitalRead(ePin) && !digitalRead(uPin) && !digitalRead(mPin)) _reboot_Teensyduino_(); // reboot to program mode if all buttons pressed
     }
   }
-  #else
+  #endif
+  #if defined(NUEVI_R1)
   if (!touchSensor.begin(0x5A)) {
     while (1){  // Touch sensor initialization failed - stop doing stuff
       if (!digitalRead(dPin) && !digitalRead(ePin) && !digitalRead(uPin) && !digitalRead(mPin)) _reboot_Teensyduino_(); // reboot to program mode if all buttons pressed
     }
   }
-  
+
   #endif
 
 
@@ -810,7 +809,8 @@ void setup() {
     statusLed(i&1);
     delay(fastBoot?75:220); //Shorter delay for fastboot
   }
-#elif defined(NUEVI_R2)
+#endif
+#if defined(NUEVI_R2)
   vibZero = vibZeroBite = breathCalZero = 0;
   const int sampleCount = 4;
   for(int i = 1 ; i <= sampleCount; ++i) {
@@ -820,7 +820,8 @@ void setup() {
     statusLed(i&1);
     delay(fastBoot?75:220); //Shorter delay for fastboot
   }
-#else
+#endif
+#if defined(PLATFORM_R1)
   vibZero = vibZeroBite = breathCalZero = 0;
   const int sampleCount = 4;
   for(int i = 1 ; i <= sampleCount; ++i) {
@@ -921,10 +922,12 @@ void loop() {
       #if defined(NURAD_R2)
       bool patchKeyEVI = 0;
       bool lockGlideKey = 0;
-      #elif defined(NUEVI_R2)
+      #endif
+      #if defined(NUEVI_R2)
       bool patchKeyEVI = patchKey;
       bool lockGlideKey = 0;
-      #else
+      #endif
+      #if defined(PLATFORM_R1)
       bool patchKeyEVI = touchRead(patchPinEVI) > patchKeyThrEVI;
       bool lockGlideKey = touchRead(lockGlidePin) > lockGlideKeyThr;
       #endif

--- a/NuEVI/adjustmenu.cpp
+++ b/NuEVI/adjustmenu.cpp
@@ -16,13 +16,13 @@ extern Adafruit_SSD1306 display;
 extern Adafruit_MPR121 touchSensorRH;
 extern Adafruit_MPR121 touchSensorLH;
 extern Adafruit_MPR121 touchSensorRollers;
-#else
+#endif
 #if defined(NUEVI_R2)
 extern Adafruit_MPR121 touchSensorRollers;
 extern Adafruit_MPR121 touchSensorRH;
-#else
-extern Adafruit_MPR121 touchSensor;
 #endif
+#if defined(NUEVI_R1)
+extern Adafruit_MPR121 touchSensor;
 #endif
 extern byte cursorNow;
 #if defined(NURAD)
@@ -171,11 +171,13 @@ void autoCalSelected() {
     calRead = map(constrain(touchSensorRollers.filteredData(extraPin), ctouchLoLimit, ctouchHiLimit), ctouchLoLimit, ctouchHiLimit, extracHiLimit, extracLoLimit);
     calReadNext = map(constrain(touchSensorRollers.filteredData(extraPin2), ctouchLoLimit, ctouchHiLimit), ctouchLoLimit, ctouchHiLimit, extracHiLimit, extracLoLimit);
     if (calReadNext > calRead) calRead = calReadNext; //use highest value
-#elif defined(NUEVI_R2)
+#endif
+#if defined(NUEVI_R2)
     calRead = map(constrain(touchSensorRollers.filteredData(extraPin), ctouchLoLimit, ctouchHiLimit), ctouchLoLimit, ctouchHiLimit, extracHiLimit, extracLoLimit);
     calReadNext = map(constrain(touchSensorRollers.filteredData(extraPin2), ctouchLoLimit, ctouchHiLimit), ctouchLoLimit, ctouchHiLimit, extracHiLimit, extracLoLimit);
     if (calReadNext > calRead) calRead = calReadNext; //use highest value
-#else
+#endif
+#if defined(PLATFORM_R1)
     calRead = touchRead(extraPin);
 #endif
     extracThrVal = constrain(calRead+200, extracLoLimit, extracHiLimit);
@@ -250,7 +252,8 @@ void autoCalSelected() {
     touch_Thr = map(ctouchThrVal,ctouchHiLimit,ctouchLoLimit,ttouchLoLimit,ttouchHiLimit);
     writeSetting(CTOUCH_THR_ADDR, ctouchThrVal);
   }
-#elif defined(NUEVI_R2)
+#endif
+#if defined(NUEVI_R2)
   // Bite sensor
   if(adjustOption == 1) {
     // Pressure sensor
@@ -262,7 +265,7 @@ void autoCalSelected() {
   }
   // Touch sensors
   if(adjustOption == 4) {
-    calRead = ctouchHiLimit;  
+    calRead = ctouchHiLimit;
     for (byte i = 6; i < 12; i++) {
       calReadNext = touchSensorRollers.filteredData(i) * (300-calOffsetRollers[i])/300;
       if (calReadNext < calRead) calRead = calReadNext; //use lowest value
@@ -275,16 +278,13 @@ void autoCalSelected() {
     touch_Thr = map(ctouchThrVal,ctouchHiLimit,ctouchLoLimit,ttouchLoLimit,ttouchHiLimit);
     writeSetting(CTOUCH_THR_ADDR, ctouchThrVal);
   }
-#else // NuEVI sensor calibration
+#endif
+#if defined(NUEVI_R1) // NuEVI R1 sensor calibration
   // Bite sensor
   if(adjustOption == 1) {
     if (digitalRead(biteJumperPin)){ //PBITE (if pulled low with jumper, pressure sensor is used instead of capacitive bite sensing)
       // Capacitive sensor
-      #if defined(NUEVI_R2)
-      //not done support for MPR121 bite pin yet
-      #else
       calRead = touchRead(bitePin);
-      #endif
       portamThrVal = constrain(calRead+200, portamLoLimit, portamHiLimit);
       portamMaxVal = constrain(portamThrVal+600, portamLoLimit, portamHiLimit);
       writeSetting(PORTAM_THR_ADDR, portamThrVal);
@@ -300,7 +300,7 @@ void autoCalSelected() {
   }
   // Touch sensors
   if(adjustOption == 4) {
-    calRead = ctouchHiLimit;  
+    calRead = ctouchHiLimit;
     for (byte i = 0; i < 12; i++) {
       calReadNext = touchSensor.filteredData(i);
       if (calReadNext < calRead) calRead = calReadNext; //use lowest value
@@ -479,7 +479,8 @@ void plotSensorPixels(){
     }
     redraw = 1;
   }
-  #elif defined(NUEVI_R2)
+  #endif
+  #if defined(NUEVI_R2)
     else if(adjustOption == 4) {
         display.drawLine(28,37,118,37,BLACK);
     for (byte i=0; i<12; i++){
@@ -495,7 +496,8 @@ void plotSensorPixels(){
     }
     redraw = 1;
   }
-  #else //NuEVI
+  #endif
+  #if defined(NUEVI_R1)
   else if(adjustOption == 4) {
     display.drawLine(28,39,118,39,BLACK);
     for (byte i=0; i<12; i++){

--- a/NuEVI/adjustmenu.cpp
+++ b/NuEVI/adjustmenu.cpp
@@ -17,7 +17,7 @@ extern Adafruit_MPR121 touchSensorRH;
 extern Adafruit_MPR121 touchSensorLH;
 extern Adafruit_MPR121 touchSensorRollers;
 #else
-#if defined(EVIR2)
+#if defined(NUEVI_R2)
 extern Adafruit_MPR121 touchSensorRollers;
 extern Adafruit_MPR121 touchSensorRH;
 #else
@@ -30,7 +30,7 @@ extern int calOffsetRollers[6];
 extern int calOffsetRH[12];
 extern int calOffsetLH[12];
 #endif
-#if defined(EVIR2)
+#if defined(NUEVI_R2)
 extern int calOffsetRollers[12];
 extern int calOffsetRH[12];
 #endif
@@ -100,7 +100,7 @@ static void extracSave(const AdjustMenuEntry& e) {
 }
 
 const AdjustMenuEntry extraSensorAdjustMenu = {
-#if defined(LITE)
+#if defined(NURAD_R2)
   "GLS/EC",
 #else
   "LIP/EC",
@@ -133,7 +133,7 @@ static void leverSave(const AdjustMenuEntry& e) {
 }
 
 const AdjustMenuEntry leverAdjustMenu = {
-  #if defined(LITE) || defined(EVIR2)
+  #if defined(PLATFORM_R2)
   "PAD", 
   #else
   "LEVER", 
@@ -167,11 +167,11 @@ void autoCalSelected() {
 // NuRAD/NuEVI sensor calibration
   // Extra Controller
   if(adjustOption == 3) {
-#if defined(LITE)
+#if defined(NURAD_R2)
     calRead = map(constrain(touchSensorRollers.filteredData(extraPin), ctouchLoLimit, ctouchHiLimit), ctouchLoLimit, ctouchHiLimit, extracHiLimit, extracLoLimit);
     calReadNext = map(constrain(touchSensorRollers.filteredData(extraPin2), ctouchLoLimit, ctouchHiLimit), ctouchLoLimit, ctouchHiLimit, extracHiLimit, extracLoLimit);
     if (calReadNext > calRead) calRead = calReadNext; //use highest value
-#elif defined(EVIR2)
+#elif defined(NUEVI_R2)
     calRead = map(constrain(touchSensorRollers.filteredData(extraPin), ctouchLoLimit, ctouchHiLimit), ctouchLoLimit, ctouchHiLimit, extracHiLimit, extracLoLimit);
     calReadNext = map(constrain(touchSensorRollers.filteredData(extraPin2), ctouchLoLimit, ctouchHiLimit), ctouchLoLimit, ctouchHiLimit, extracHiLimit, extracLoLimit);
     if (calReadNext > calRead) calRead = calReadNext; //use highest value
@@ -193,7 +193,7 @@ void autoCalSelected() {
   }
   // Pitch Bend
   if(adjustOption == 2) {
- #if defined(LITE) || defined(EVIR2)
+ #if defined(PLATFORM_R2)
     calRead = map(constrain(touchSensorRollers.filteredData(pbUpPin), ctouchLoLimit, ctouchHiLimit), ctouchLoLimit, ctouchHiLimit, pitchbHiLimit, pitchbLoLimit);
     calReadNext = map(constrain(touchSensorRollers.filteredData(pbDnPin), ctouchLoLimit, ctouchHiLimit), ctouchLoLimit, ctouchHiLimit, pitchbHiLimit, pitchbLoLimit);
 #else
@@ -208,12 +208,12 @@ void autoCalSelected() {
   }
   // Lever
   if(adjustOption == 5) {
-#if defined(LITE) || defined(EVIR2)
+#if defined(PLATFORM_R2)
     calRead = map(constrain(touchSensorRollers.filteredData(vibratoPin), ctouchLoLimit, ctouchHiLimit), ctouchLoLimit, ctouchHiLimit, leverHiLimit, leverLoLimit);
 #else
     calRead = touchRead(vibratoPin);
 #endif
-#if defined(SEAMUS) || defined(LITE) || defined(EVIR2)
+#if defined(SEAMUS) || defined(PLATFORM_R2)
 #else
     calRead = 3000-calRead;
 #endif
@@ -250,7 +250,7 @@ void autoCalSelected() {
     touch_Thr = map(ctouchThrVal,ctouchHiLimit,ctouchLoLimit,ttouchLoLimit,ttouchHiLimit);
     writeSetting(CTOUCH_THR_ADDR, ctouchThrVal);
   }
-#elif defined(EVIR2)
+#elif defined(NUEVI_R2)
   // Bite sensor
   if(adjustOption == 1) {
     // Pressure sensor
@@ -280,7 +280,7 @@ void autoCalSelected() {
   if(adjustOption == 1) {
     if (digitalRead(biteJumperPin)){ //PBITE (if pulled low with jumper, pressure sensor is used instead of capacitive bite sensing)
       // Capacitive sensor
-      #if defined(EVIR2)
+      #if defined(NUEVI_R2)
       //not done support for MPR121 bite pin yet
       #else
       calRead = touchRead(bitePin);
@@ -432,7 +432,7 @@ void plotSensorPixels(){
     if (biteJumper) { //PBITE (if pulled low with jumper or if on a NuRAD, use pressure sensor instead of capacitive bite sensor)
       biteSensor=analogRead(bitePressurePin); // alternative kind bite sensor (air pressure tube and sensor)  PBITE
     } else {
-#if defined(LITE) || defined(EVIR2)
+#if defined(PLATFORM_R2)
 #else
       biteSensor = touchRead(bitePin);     // get sensor data, do some smoothing - SENSOR PIN 17 - PCB PINS LABELED "BITE" (GND left, sensor pin right)
 #endif
@@ -445,7 +445,7 @@ void plotSensorPixels(){
     int pos2 = map(constrain(pbDn, pitchbLoLimit, pitchbHiLimit), pitchbLoLimit, pitchbHiLimit, 28, 118);
     redraw = updateSensorPixel(pos, pos2);
   }
-  #if defined(LITE) || defined(EVIR2)
+  #if defined(PLATFORM_R2)
   else if(adjustOption == 3) {
     int pos = map(constrain(exSensor, extracLoLimit, extracHiLimit), extracLoLimit, extracHiLimit, 28, 118);
     int pos2 = map(constrain(exSensor2, extracLoLimit, extracHiLimit), extracLoLimit, extracHiLimit, 28, 118);
@@ -479,7 +479,7 @@ void plotSensorPixels(){
     }
     redraw = 1;
   }
-  #elif defined(EVIR2)
+  #elif defined(NUEVI_R2)
     else if(adjustOption == 4) {
         display.drawLine(28,37,118,37,BLACK);
     for (byte i=0; i<12; i++){
@@ -515,12 +515,12 @@ void plotSensorPixels(){
   }
   #endif
   else if(adjustOption == 5) {
-#if defined(LITE) || defined(EVIR2)
+#if defined(PLATFORM_R2)
   int rd = map(constrain(touchSensorRollers.filteredData(vibratoPin), ctouchLoLimit, ctouchHiLimit), ctouchLoLimit, ctouchHiLimit, leverHiLimit, leverLoLimit);
 #else
   int rd = touchRead(vibratoPin);
 #endif
-#if defined(SEAMUS) || defined(LITE) || defined(EVIR2)
+#if defined(SEAMUS) || defined(PLATFORM_R2)
     int pos = map(constrain(rd, leverLoLimit, leverHiLimit), leverLoLimit, leverHiLimit, 28, 118);
 #else
      int pos = map(constrain(3000-rd, leverLoLimit, leverHiLimit), leverLoLimit, leverHiLimit, 28, 118);

--- a/NuEVI/hardware.h
+++ b/NuEVI/hardware.h
@@ -2,21 +2,42 @@
 #define __HARDWARE_H
 #endif
 
-//Platform-specific defines if using Arduino IDE. You need to set the "instrument type", the "instrument version" and the "platform",
-//for example NURAD + NURAD_R2 + PLATFORM_R2 if building for NuRAD R2. SEAMUS can be used in conjunction with NURAD / NURAD_R1 / PLATFORM_R1.
+//Platform-specific defines if using Arduino IDE.
+// Only need to set the specific variant (and SEAMUS if applicable);
 
-//#define NURAD
 //#define NURAD_R1
 //#define NURAD_R2
-//#define NUEVI
 //#define NUEVI_R1
 //#define NUEVI_R2
-//#define SEAMUS
+//#define SEAMUS  // only in conjunction with NURAD_R1
 
 //#define I2CSCANNER
 
-#if defined(NURAD) //NuRAD <<<<<<<<<<<<<<<<<<<<<<<
-#if defined(NURAD_R2)  //NuRAD R2
+// Implied family and generation flags — derived from the specific variant define above.
+// These do not need to be set manually or in platformio.ini.
+#if defined(NURAD_R1) || defined(NURAD_R2)
+  #define NURAD
+#endif
+#if defined(NUEVI_R1) || defined(NUEVI_R2)
+  #define NUEVI
+#endif
+#if defined(NURAD_R1) || defined(NUEVI_R1)
+  #define PLATFORM_R1
+#endif
+#if defined(NURAD_R2) || defined(NUEVI_R2)
+  #define PLATFORM_R2
+#endif
+
+//Check that exactly one of the specific variant flags is set
+#if !(defined(NURAD_R1) || defined(NURAD_R2) || defined(NUEVI_R1) || defined(NUEVI_R2))
+#error "No target specified. Please define exactly one of NURAD_R1, NURAD_R2, NUEVI_R1 or NUEVI_R2."
+#endif
+
+#if (defined(NURAD) && defined(NUEVI)) || (!defined(PLATFORM_R1) && !defined(PLATFORM_R2))
+#error "Multiple incompatible target flags defined. Please define exactly one of NURAD_R1, NURAD_R2, NUEVI_R1 or NUEVI_R2."
+#endif
+
+#if defined(NURAD_R2)  //NuRAD R2 <<<<<<<<<<<<<<<<<<<<<<<
 
 // Pin definitions
 
@@ -97,7 +118,9 @@
 #define LHp3Pin 4
 
 
-#else //Regular NuRAD
+#endif
+
+#if defined(NURAD_R1)  //Regular NuRAD
 // Pin definitions
 
 // Teensy pins
@@ -180,8 +203,8 @@
 #define LHp3Pin 4
 
 #endif
-#else //NuEVI <<<<<<<<<<<<<<<<<<<<<<<
-#if defined(NUEVI_R2)  //NuEVI R2
+
+#if defined(NUEVI_R2)  //NuEVI R2 <<<<<<<<<<<<<<<<<<<<<<<
 
 //Analog pressure sensors. Breath and optional bite
 #define breathSensorPin A0
@@ -245,7 +268,9 @@
 #define patchPinEVI 6
 #define lockGlidePin 7
 
-#else
+#endif
+
+#if defined(NUEVI_R1)
 // Pin definitions
 
 // Teensy pins
@@ -326,6 +351,5 @@
  */
 
 
-#endif //NUEVI_R2
-#endif //NURAD
+#endif //NUEVI_R1
 

--- a/NuEVI/hardware.h
+++ b/NuEVI/hardware.h
@@ -3,15 +3,22 @@
 #endif
 
 #define REVB
+
+//Platform-specific defines if using Arduino IDE. You need to set both the "main type" and the "platform",
+//for example NURAD + NURAD_R2 if building for NuRAD R2. SEAMUS can be used in conjunction with NURAD and NURAD_R1.
+
 //#define NURAD
+//#define NURAD_R1
+//#define NURAD_R2
+//#define NUEVI
+//#define NUEVI_R1
+//#define NUEVI_R2
 //#define SEAMUS
-//#define LITE
-//#define EVIR2
 
 //#define I2CSCANNER
 
 #if defined(NURAD) //NuRAD <<<<<<<<<<<<<<<<<<<<<<<
-#if defined(LITE)  //NuRAD lite
+#if defined(NURAD_R2)  //NuRAD R2
 
 // Pin definitions
 
@@ -176,7 +183,7 @@
 
 #endif
 #else //NuEVI <<<<<<<<<<<<<<<<<<<<<<<
-#if defined(EVIR2)  //NuEVI R2
+#if defined(NUEVI_R2)  //NuEVI R2
 
 //Analog pressure sensors. Breath and optional bite
 #define breathSensorPin A0
@@ -350,6 +357,6 @@
  */
 
 #endif //REVB
-#endif //EVIR2
+#endif //NUEVI_R2
 #endif //NURAD
 

--- a/NuEVI/hardware.h
+++ b/NuEVI/hardware.h
@@ -33,8 +33,12 @@
 #error "No target specified. Please define exactly one of NURAD_R1, NURAD_R2, NUEVI_R1 or NUEVI_R2."
 #endif
 
-#if (defined(NURAD) && defined(NUEVI)) || (!defined(PLATFORM_R1) && !defined(PLATFORM_R2))
+#if (defined(NURAD) && defined(NUEVI)) || (defined(PLATFORM_R1) && defined(PLATFORM_R2))
 #error "Multiple incompatible target flags defined. Please define exactly one of NURAD_R1, NURAD_R2, NUEVI_R1 or NUEVI_R2."
+#endif
+
+#if (defined(SEAMUS) && !defined(NURAD_R1))
+#error "SEAMUS can only be used together with NURAD_R1."
 #endif
 
 #if defined(NURAD_R2)  //NuRAD R2 <<<<<<<<<<<<<<<<<<<<<<<

--- a/NuEVI/hardware.h
+++ b/NuEVI/hardware.h
@@ -2,10 +2,8 @@
 #define __HARDWARE_H
 #endif
 
-#define REVB
-
-//Platform-specific defines if using Arduino IDE. You need to set both the "main type" and the "platform",
-//for example NURAD + NURAD_R2 if building for NuRAD R2. SEAMUS can be used in conjunction with NURAD and NURAD_R1.
+//Platform-specific defines if using Arduino IDE. You need to set the "instrument type", the "instrument version" and the "platform",
+//for example NURAD + NURAD_R2 + PLATFORM_R2 if building for NuRAD R2. SEAMUS can be used in conjunction with NURAD / NURAD_R1 / PLATFORM_R1.
 
 //#define NURAD
 //#define NURAD_R1
@@ -302,8 +300,6 @@
 #define MIDI_SERIAL Serial3
 #define WIDI_SERIAL Serial2
 
-#if defined(REVB)
-
 // MPR121 pins Rev B (angled pins at top edge for main keys and rollers)
 
 #define R1Pin 0
@@ -329,34 +325,7 @@
  *
  */
 
-# else //REV A
 
-// MPR121 pins Rev A (upright pins below MPR121 for main keys and rollers)
-
-#define R1Pin 10
-#define R2Pin 11
-#define R3Pin 8
-#define R4Pin 9
-#define R5Pin 6
-
-#define K4Pin 7
-#define K1Pin 4
-#define K2Pin 5
-#define K3Pin 2
-#define K5Pin 3
-#define K6Pin 0
-#define K7Pin 1
-
-/*
- *    PINOUT ON PCB vs PINS ON MPR121 - Rev. A
- *
- *    (R2)  (R4)  (K4)  (K2)  (K5)  (K7)  <-> (11)  (09)  (07)  (05)  (03)  (01)
- *
- *    (R1) (R3/6) (R5)  (K1)  (K3)  (K6)  <-> (10)  (08)  (06)  (04)  (02)  (00)
- *
- */
-
-#endif //REVB
 #endif //NUEVI_R2
 #endif //NURAD
 

--- a/NuEVI/menu.cpp
+++ b/NuEVI/menu.cpp
@@ -1166,7 +1166,7 @@ const MenuEntrySub gateOpenMenu = {
   , nullptr
 };
 
-#if !defined(NURAD)
+#if defined(NUEVI)
 const MenuEntrySub trill3Menu = {
   MenuType::ESub, "3RD TRILL", "3RD TRILL", &trill3_interval, 3, 4, MenuEntryFlags::ENone,
   [](SubMenuRef __unused, char* out, const char** __unused unit) {
@@ -1548,13 +1548,13 @@ const MenuEntrySub biteCCMenu = {
 };
 
 const MenuEntrySub leverCtlMenu = {
-#if defined(LITE) || defined(EVIR2)
+#if defined(PLATFORM_R2)
   MenuType::ESub, "PAD CTL", "PAD DEST", &leverControl, 0, 3, MenuEntryFlags::EMenuEntryWrap,
 #else
   MenuType::ESub, "LEVER CTL", "LEVER DEST", &leverControl, 0, 3, MenuEntryFlags::EMenuEntryWrap,
 #endif
   [](SubMenuRef __unused,char* out, const char ** __unused unit) {
-    #if defined(EVIR2)
+    #if defined(NUEVI_R2)
     const char* labs[] = { "OFF", "OFF", "GLD", "CC" };
     #else
     const char* labs[] = { "OFF", "VIB", "GLD", "CC" };
@@ -1566,7 +1566,7 @@ const MenuEntrySub leverCtlMenu = {
 };
 
 const MenuEntrySub leverCCMenu = {
-#if defined(LITE) || defined(EVIR2)
+#if defined(PLATFORM_R2)
   MenuType::ESub, "PAD CC",  "CC NUMBER", &leverCC, 0, 127, MenuEntryFlags::EMenuEntryWrap,
 #else
   MenuType::ESub, "LEVER CC",  "CC NUMBER", &leverCC, 0, 127, MenuEntryFlags::EMenuEntryWrap,
@@ -1578,9 +1578,9 @@ const MenuEntrySub leverCCMenu = {
   , nullptr
 };
 
-#if (defined(NURAD) && defined(LITE)) || defined(EVIR2)
+#if defined(PLATFORM_R2)
 const MenuEntrySub stripCtlMenu = {
-#if defined(EVIR2)
+#if defined(NUEVI_R2)
   MenuType::ESub, "AUX CTL", "AUX DEST", &stripControl, 0, 2, MenuEntryFlags::EMenuEntryWrap,
 #else
   MenuType::ESub, "STRIP CTL", "STRIP DEST", &stripControl, 0, 2, MenuEntryFlags::EMenuEntryWrap,
@@ -1594,7 +1594,7 @@ const MenuEntrySub stripCtlMenu = {
 };
 
 const MenuEntrySub stripCCMenu = {
-#if defined(EVIR2)
+#if defined(NUEVI_R2)
     MenuType::ESub, "AUX CC",  "CC NUMBER", &stripCC, 0, 127, MenuEntryFlags::EMenuEntryWrap,
 #else
   MenuType::ESub, "STRIP CC",  "CC NUMBER", &stripCC, 0, 127, MenuEntryFlags::EMenuEntryWrap,
@@ -1812,7 +1812,7 @@ const MenuEntry* controlMenuEntries[] = {
   (MenuEntry*)&extraCC2Menu,
   (MenuEntry*)&harmonicsMenu,
   (MenuEntry*)&harmSelectMenu,
-  #if defined(LITE)
+  #if defined(NURAD_R2)
   (MenuEntry*)&stripCtlMenu,
   (MenuEntry*)&stripCCMenu,
   #endif
@@ -1824,7 +1824,7 @@ const MenuEntry* controlMenuEntries[] = {
   (MenuEntry*)&rollerMenu,
   (MenuEntry*)&pitchBendMenu
 };
-#elif defined(EVIR2)
+#elif defined(NUEVI_R2)
 const MenuEntry* controlMenuEntries[] = {
   (MenuEntry*)&biteCtlMenu,
   (MenuEntry*)&biteCCMenu,
@@ -1911,7 +1911,7 @@ const MenuEntrySub vibRetnMenu = {
 };
 
 const MenuEntrySub vibSenseMenu = {
-#if defined(LITE)
+#if defined(NURAD_R2)
   MenuType::ESub, "SENSE PAD", "LEVEL", &vibSens, 1, 12, MenuEntryFlags::ENone,
 #else
   MenuType::ESub, "SENSE LVR", "LEVEL", &vibSens, 1, 12, MenuEntryFlags::ENone,
@@ -1924,7 +1924,7 @@ const MenuEntrySub vibSenseMenu = {
 };
 
 const MenuEntrySub vibSquelchMenu = {
-#if defined(LITE)
+#if defined(NURAD_R2)
   MenuType::ESub, "SQUELCH P", "LEVEL", &vibSquelch, 1, 30, MenuEntryFlags::ENone,
 #else
   MenuType::ESub, "SQUELCH L", "LEVEL", &vibSquelch, 1, 30, MenuEntryFlags::ENone,

--- a/NuEVI/menu.cpp
+++ b/NuEVI/menu.cpp
@@ -1582,7 +1582,7 @@ const MenuEntrySub leverCCMenu = {
 const MenuEntrySub stripCtlMenu = {
 #if defined(NUEVI_R2)
   MenuType::ESub, "AUX CTL", "AUX DEST", &stripControl, 0, 2, MenuEntryFlags::EMenuEntryWrap,
-#else
+#elif defined(NURAD_R2)
   MenuType::ESub, "STRIP CTL", "STRIP DEST", &stripControl, 0, 2, MenuEntryFlags::EMenuEntryWrap,
 #endif
   [](SubMenuRef __unused,char* out, const char ** __unused unit) {
@@ -1596,7 +1596,7 @@ const MenuEntrySub stripCtlMenu = {
 const MenuEntrySub stripCCMenu = {
 #if defined(NUEVI_R2)
     MenuType::ESub, "AUX CC",  "CC NUMBER", &stripCC, 0, 127, MenuEntryFlags::EMenuEntryWrap,
-#else
+#elif defined(NURAD_R2)
   MenuType::ESub, "STRIP CC",  "CC NUMBER", &stripCC, 0, 127, MenuEntryFlags::EMenuEntryWrap,
 #endif
     [](SubMenuRef __unused, char* out, const char** __unused unit) {
@@ -1824,7 +1824,8 @@ const MenuEntry* controlMenuEntries[] = {
   (MenuEntry*)&rollerMenu,
   (MenuEntry*)&pitchBendMenu
 };
-#elif defined(NUEVI_R2)
+#endif
+#if defined(NUEVI_R2)
 const MenuEntry* controlMenuEntries[] = {
   (MenuEntry*)&biteCtlMenu,
   (MenuEntry*)&biteCCMenu,
@@ -1847,7 +1848,8 @@ const MenuEntry* controlMenuEntries[] = {
   (MenuEntry*)&rollerMenu,
   (MenuEntry*)&pitchBendMenu
 };
-#else
+#endif
+#if defined(NUEVI_R1)
 const MenuEntry* controlMenuEntries[] = {
   (MenuEntry*)&biteCtlMenu,
   (MenuEntry*)&biteCCMenu,

--- a/NuEVI/platformio.ini
+++ b/NuEVI/platformio.ini
@@ -23,18 +23,18 @@ lib_deps =
   adafruit/Adafruit SSD1306 @ ^2.5.7
 
 [env:nuevi]
-build_flags = ${env.build_flags}
+build_flags = ${env.build_flags} -D NUEVI_R1 -D NUEVI -D PLATFORM_R1
 
 [env:nurad]
-build_flags = ${env.build_flags} -D NURAD
+build_flags = ${env.build_flags} -D NURAD -D NURAD_R1 -D PLATFORM_R1
 
 [env:nurad_seamus]
-build_flags = ${env.build_flags} -D NURAD -D SEAMUS
+build_flags = ${env.build_flags} -D NURAD -D NURAD_R1 -D SEAMUS -D PLATFORM_R1
 
 [env:nurad_teensy40]
-build_flags = ${env.build_flags} -D NURAD -D LITE
+build_flags = ${env.build_flags} -D NURAD -D NURAD_R2 -D PLATFORM_R2
 board = teensy40
 
 [env:nuevi_teensy40]
-build_flags = ${env.build_flags} -D EVIR2
+build_flags = ${env.build_flags} -D NUEVI_R2 -D NUEVI -D PLATFORM_R2
 board = teensy40

--- a/NuEVI/platformio.ini
+++ b/NuEVI/platformio.ini
@@ -13,14 +13,16 @@
 src_dir = .
 
 [env]
-platform = teensy
+platform = teensy@5.0
 board = teensy31
 framework = arduino
 build_flags = -D USB_MIDI -D TEENSY_OPT_FASTER
 board_build.f_cpu = 96000000L
 lib_deps =
-  adafruit/Adafruit MPR121 @ 1.1.1
-  adafruit/Adafruit SSD1306 @ ^2.5.7
+  adafruit/Adafruit MPR121 @ 1.1.3
+  adafruit/Adafruit SSD1306 @ 2.5.16
+  adafruit/Adafruit BusIO @ 1.17.4
+  adafruit/Adafruit GFX Library @ 1.12.5
 
 [env:nuevi]
 build_flags = ${env.build_flags} -D NUEVI_R1

--- a/NuEVI/platformio.ini
+++ b/NuEVI/platformio.ini
@@ -23,18 +23,18 @@ lib_deps =
   adafruit/Adafruit SSD1306 @ ^2.5.7
 
 [env:nuevi]
-build_flags = ${env.build_flags} -D NUEVI_R1 -D NUEVI -D PLATFORM_R1
+build_flags = ${env.build_flags} -D NUEVI_R1
 
 [env:nurad]
-build_flags = ${env.build_flags} -D NURAD -D NURAD_R1 -D PLATFORM_R1
+build_flags = ${env.build_flags} -D NURAD_R1
 
 [env:nurad_seamus]
-build_flags = ${env.build_flags} -D NURAD -D NURAD_R1 -D SEAMUS -D PLATFORM_R1
+build_flags = ${env.build_flags} -D NURAD_R1 -D SEAMUS
 
 [env:nurad_teensy40]
-build_flags = ${env.build_flags} -D NURAD -D NURAD_R2 -D PLATFORM_R2
+build_flags = ${env.build_flags} -D NURAD_R2
 board = teensy40
 
 [env:nuevi_teensy40]
-build_flags = ${env.build_flags} -D NUEVI_R2 -D NUEVI -D PLATFORM_R2
+build_flags = ${env.build_flags} -D NUEVI_R2
 board = teensy40

--- a/README.md
+++ b/README.md
@@ -9,16 +9,16 @@ Follow the project at https://hackaday.io/project/25756-diy-evi-style-windcontro
 This project is designed to be built using [PlatformIO](https://platformio.org/install/). If using the command-line tools, just build using `pio run` (or `pio run -e nuevi` for a specific build target).
 
 It can also be built using the Arduino IDE. You will also need to download and install
-[Teensyduino](https://www.pjrc.com/teensy/td_download.html) to build for and upload to the Teensy. You need to edit hardware.h to configure it for your platform.
+[Teensyduino](https://www.pjrc.com/teensy/td_download.html) to build for and upload to the Teensy. You need to edit [hardware.h](NuEVI/hardware.h) to configure it for your platform.
 
 ### Libraries
 
 A few libraries need to be added that are not part of the default Arduino install. These need to be added via the Library Manager in the Arduino IDE:
-* Adafruit MPR121 (version 1.1.1. 1.2.0 and later have compatibility issues with Teensy 3.2)
+* Adafruit MPR121 (version 1.1.x. 1.2.0 and later have compatibility issues with Teensy 3.2)
 * Adafruit GFX
-* Adafruit SSD1306 (version 1.2.9 or above)
+* Adafruit SSD1306
 * NuEVI also includes the [Filters](https://github.com/JonHub/Filters) library by Jonathan Driscoll, but that is no longer an external dependency.
-
+Usually the latest version will work (except MPR121), to see the exact version used check in [platformio.ini](NuEVI/platformio.ini).
 
 ### Compile options
 

--- a/README.md
+++ b/README.md
@@ -6,13 +6,14 @@ Follow the project at https://hackaday.io/project/25756-diy-evi-style-windcontro
 
 ## Building NuEVI
 
-NuEVI is easiest to build using the Arduino IDE. You will also need to download and install
-[Teensyduino](https://www.pjrc.com/teensy/td_download.html) to build for and upload to the Teensy.
+This project is designed to be built using [PlatformIO](https://platformio.org/install/). If using the command-line tools, just build using `pio run` (or `pio run -e nuevi` for a specific build target).
+
+It can also be built using the Arduino IDE. You will also need to download and install
+[Teensyduino](https://www.pjrc.com/teensy/td_download.html) to build for and upload to the Teensy. You need to edit hardware.h to configure it for your platform.
 
 ### Libraries
 
-A few libraries need to be added that are not part of the default Arduino install. These can be
-added directly via the Library Manager in the Arduino IDE:
+A few libraries need to be added that are not part of the default Arduino install. These need to be added via the Library Manager in the Arduino IDE:
 * Adafruit MPR121 (version 1.1.1. 1.2.0 and later have compatibility issues with Teensy 3.2)
 * Adafruit GFX
 * Adafruit SSD1306 (version 1.2.9 or above)
@@ -21,8 +22,8 @@ added directly via the Library Manager in the Arduino IDE:
 
 ### Compile options
 
-Open NuEVI.ino in the Arduino IDE. Under "Tools -> Board", select "Teensy 3.2 / 3.1". Then set
-"Tools -> USB Type" to "MIDI".
+Open NuEVI.ino in the Arduino IDE. Under "Tools -> Board", select "Teensy 3.2 / 3.1" for NuEVI/NuRAD R1, or "Teensy 4.0" for NuEVI/NuRAD R2.
+Then set "Tools -> USB Type" to "MIDI".
 
 ### Building and uploading
 


### PR DESCRIPTION
Replace previous defines for platforms/targets with these:

`NUEVI_R1`
`NUEVI_R2`
`NURAD_R1`
`NURAD_R2`

And `SEAMUS` as an "optional extra" for `NURAD_R1`.

Some `#if` statements have been broken apart for readability, as separate clauses instead of nested if-else-endif.

A bunch of preprocessor checks in hardware.h to verify incorrect combinations aren't used (this should generate lots of other compile errors, but it might provide some useful hints).